### PR TITLE
chore: Entity PK 생성 방식 수정

### DIFF
--- a/backend/src/main/java/force/ssafy/domain/algorithm/entity/Algorithm.java
+++ b/backend/src/main/java/force/ssafy/domain/algorithm/entity/Algorithm.java
@@ -1,19 +1,15 @@
 package force.ssafy.domain.algorithm.entity;
 
 import force.ssafy.domain.problemAlgorithm.entity.ProblemAlgorithm;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
+
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 public class Algorithm {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
     @Column(nullable = false)
     private String name;

--- a/backend/src/main/java/force/ssafy/domain/problem/entity/Problem.java
+++ b/backend/src/main/java/force/ssafy/domain/problem/entity/Problem.java
@@ -1,21 +1,15 @@
 package force.ssafy.domain.problem.entity;
 
 import force.ssafy.domain.problemAlgorithm.entity.ProblemAlgorithm;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
+
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 public class Problem {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
     @Column(nullable = false)

--- a/backend/src/main/java/force/ssafy/domain/problemAlgorithm/entity/ProblemAlgorithm.java
+++ b/backend/src/main/java/force/ssafy/domain/problemAlgorithm/entity/ProblemAlgorithm.java
@@ -2,17 +2,12 @@ package force.ssafy.domain.problemAlgorithm.entity;
 
 import force.ssafy.domain.algorithm.entity.Algorithm;
 import force.ssafy.domain.problem.entity.Problem;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 
 @Entity
 public class ProblemAlgorithm {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/force/ssafy/domain/solvedProblem/entity/SolvedProblem.java
+++ b/backend/src/main/java/force/ssafy/domain/solvedProblem/entity/SolvedProblem.java
@@ -1,18 +1,14 @@
 package force.ssafy.domain.solvedProblem.entity;
 
 import force.ssafy.domain.problem.entity.Problem;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 
 @Entity
 public class SolvedProblem {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
 //    @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## 🔍 변경사항
<!-- 이번 PR에서 변경된 내용을 간략히 설명해주세요 -->
`@GeneratedValue`의 경우, PK 생성 방식을 지정하지 않으면, sequence를 생성하는 방식으로 추가적인 테이블을 만들어야 함. 이를 막기 위해 MySQL에게 PK 할당을 위임하고자 `(strategy = GenerationType.IDENTITY)` 옵션을 추가

## 💬리뷰 요구사항
<!-- 코드 리뷰시 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. -->
의도적으로 strategy 지정하지 않은 것인지 궁금함

## 🔗 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 (ex. #123) -->
#1 

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
![스크린샷 2025-04-21 210005](https://github.com/user-attachments/assets/e50d1f55-d514-41f0-866c-aee36ceadf5b)
- strategy를 설정하지 않았을 때의 테이블 구조
