### PR TITLE
Feat: 리프레시 토큰 갱신 API 구현

### DIFF
--- a/backend/src/main/java/force/ssafy/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/force/ssafy/domain/auth/controller/AuthController.java
@@ -1,9 +1,11 @@
 package force.ssafy.domain.auth.controller;
 
 
+import force.ssafy.domain.auth.dto.request.RefreshTokenRequestDto;
 import force.ssafy.domain.auth.dto.request.SignInDto;
 import force.ssafy.domain.auth.dto.request.SignUpDto;
 import force.ssafy.domain.auth.dto.response.TokenDto;
+import force.ssafy.domain.auth.exception.AuthenticationException;
 import force.ssafy.domain.auth.service.AuthService;
 import force.ssafy.domain.member.dto.response.MemberDto;
 import force.ssafy.domain.member.entity.Member;
@@ -12,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -56,5 +60,22 @@ public class AuthController {
         String accessToken = token.replace("Bearer ", "");
         authService.signOut(accessToken);
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 토큰 갱신 API
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshToken(@Valid @RequestBody RefreshTokenRequestDto request) {
+        try {
+            TokenDto tokenDto = authService.refreshToken(request.getRefreshToken());
+            return ResponseEntity.ok(tokenDto);
+        } catch (AuthenticationException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("error", "유효하지 않은 리프레시 토큰입니다."));
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("error", e.getMessage()));
+        }
     }
 }

--- a/backend/src/main/java/force/ssafy/domain/auth/dto/request/RefreshTokenRequestDto.java
+++ b/backend/src/main/java/force/ssafy/domain/auth/dto/request/RefreshTokenRequestDto.java
@@ -1,0 +1,13 @@
+package force.ssafy.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefreshTokenRequestDto {
+
+    @NotBlank(message = "리프레시 토큰은 필수 입력값입니다.")
+    private String refreshToken;
+}


### PR DESCRIPTION
- POST /api/v1/auth/refresh 엔드포인트 추가
- 만료된 액세스 토큰 갱신을 위한 리프레시 토큰 처리 로직 구현
- RefreshTokenRequest DTO 생성으로 리프레시 토큰 요청 유효성 검증
- 리프레시 토큰 유효성 검사 및 신규 액세스 토큰 발급 로직 추가
- 다양한 오류 상황 처리(토큰 만료, 유효하지 않은 토큰, 토큰 누락 등)
- 회원 인증 상태 유지를 위한 토큰 자동 갱신 메커니즘 구현

JWT 기반 인증 시스템의 보안성 향상 및 사용자 경험 개선

## 🔍 변경사항
<!-- 이번 PR에서 변경된 내용을 간략히 설명해주세요 -->
#25 
## 💬리뷰 요구사항
<!-- 코드 리뷰시 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. -->

## 🔗 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 (ex. #123) -->

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

< 리프래시 토큰 값이 비어있을 경우 >
<img width="705" alt="image" src="https://github.com/user-attachments/assets/8466f642-901e-4b26-a849-7061d447935a" />

< 유효하지 않은 토큰인 경우 >
<img width="685" alt="image" src="https://github.com/user-attachments/assets/22960947-d2ba-4e9a-b847-432fb8e98f83" />

< 유효한 토큰인 경우 >
<img width="630" alt="image" src="https://github.com/user-attachments/assets/3ea6c093-de52-451d-87b6-072d95775a45" />
