### PR TITLE
Feat: 비밀번호 재설정 기능 개발

### DIFF
--- a/backend/src/main/java/force/ssafy/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/force/ssafy/domain/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package force.ssafy.domain.member.controller;
 
 import force.ssafy.domain.member.dto.request.MemberUpdateRequest;
 import force.ssafy.domain.member.dto.request.PasswordChangeDto;
+import force.ssafy.domain.member.dto.request.PasswordResetDto;
 import force.ssafy.domain.member.dto.response.MemberDto;
 import force.ssafy.domain.member.dto.response.MemberUpdateResponse;
 import force.ssafy.domain.member.dto.response.NicknameVerificationDto;
@@ -60,6 +61,16 @@ public class MemberController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody PasswordChangeDto passwordChangeDto) {
         memberService.changePassword(userDetails.getMemberId(), passwordChangeDto);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 비밀번호 재설정 API
+     */
+    @PostMapping("/password/reset")
+    public ResponseEntity<Void> resetPassword(
+            @Valid @RequestBody PasswordResetDto passwordResetDto) {
+        memberService.resetPassword(passwordResetDto);
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/force/ssafy/domain/member/dto/request/PasswordResetDto.java
+++ b/backend/src/main/java/force/ssafy/domain/member/dto/request/PasswordResetDto.java
@@ -1,0 +1,20 @@
+package force.ssafy.domain.member.dto.request;
+
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PasswordResetDto {
+
+    @NotBlank(message = "닉네임은 필수 입력값입니다.")
+    private String solvedAcId;
+
+
+    @NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
+    @Size(min = 6, message = "비밀번호는 최소 6자 이상이어야 합니다.")
+    private String newPassword;
+}

--- a/backend/src/main/java/force/ssafy/domain/member/service/MemberService.java
+++ b/backend/src/main/java/force/ssafy/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package force.ssafy.domain.member.service;
 
 import force.ssafy.domain.member.dto.request.MemberUpdateRequest;
 import force.ssafy.domain.member.dto.request.PasswordChangeDto;
+import force.ssafy.domain.member.dto.request.PasswordResetDto;
 import force.ssafy.domain.member.dto.response.MemberDto;
 import force.ssafy.domain.member.dto.response.NicknameVerificationDto;
 import force.ssafy.domain.member.entity.Member;
@@ -9,6 +10,7 @@ import force.ssafy.domain.member.exception.InvalidPasswordException;
 import force.ssafy.domain.member.exception.MemberNotFoundException;
 import force.ssafy.domain.member.repository.MemberRepository;
 import force.ssafy.global.security.userdetails.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -82,7 +84,7 @@ public class MemberService implements UserDetailsService {
                 updateDto.getProfileImage()
         );
 
-        memberRepository.save(member);
+        //memberRepository.save(member);
     }
 
     /**
@@ -101,7 +103,20 @@ public class MemberService implements UserDetailsService {
         // 새 비밀번호 설정
         member.updatePassword(passwordEncoder.encode(passwordChangeDto.getNewPassword()));
 
-        memberRepository.save(member);
+        //memberRepository.save(member);
+    }
+
+
+    /**
+     * 비밀번호 재설정
+     */
+    @Transactional
+    public void resetPassword(PasswordResetDto passwordResetDto) {
+        Member member = memberRepository.findBySolvedAcId(passwordResetDto.getSolvedAcId())
+                .orElseThrow(() -> new MemberNotFoundException("회원을 찾을 수 없습니다. "));
+
+        // 새 비밀번호 설정
+        member.updatePassword(passwordEncoder.encode(passwordResetDto.getNewPassword()));
     }
 
     /**

--- a/backend/src/main/java/force/ssafy/domain/teamMember/repository/TeamMemberRepository.java
+++ b/backend/src/main/java/force/ssafy/domain/teamMember/repository/TeamMemberRepository.java
@@ -1,6 +1,5 @@
 package force.ssafy.domain.teamMember.repository;
 
-import force.ssafy.domain.member.entity.Member;
 import force.ssafy.domain.teamMember.dto.TeamMemberDto;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -16,7 +15,7 @@ public class TeamMemberRepository {
 
     public List<TeamMemberDto> findTeamMemberDtoByTeamId(Long teamId) {
         return em.createQuery(
-                        "SELECT new force.ssafy.domain.teamMember.dto.TeamMemberDto(m.id, m.nickname, m.name, m.profileImage) " +
+                        "SELECT new force.ssafy.domain.teamMember.dto.TeamMemberDto(m.id, m.solvedAcId, m.name, m.profileImage) " +
                                 "FROM TeamMember tm " +
                                 "JOIN tm.member m " +
                                 "WHERE tm.team.id = :teamId",


### PR DESCRIPTION
## 🔍 변경사항
- 비밀번호 재설정 기능을 추가하였습니다. 
- 멤버의 nickname 필드값을 사용하는 것을 수정하였습니다. 

## 💬리뷰 요구사항
- 로그인한 사용자에 대한 비밀번호 변경 기능은 존재했기 때문에, 비로그인 사용자에 대한 비밀번호 재설정(초기화) 기능을 만들었습니다. 
- memberService 에 불필요한 save() 문이 있어 주석처리 하였습니다. 
  - 영속된 상태에 있는 멤버의 속성을 변경하면, 트랜잭션이 끝나는 시점에 자동으로 변경된 내용에 대한 쿼리가 날라갑니다(변경 감지)
- 팀멤버 리포지토리에 사용되는 nickname 필드값을 사용을 수정하였습니다. 
  - 실제 쿼리가 날라가는 부분만 수정했고, dto 부분은 의미가 동일하여 굳이 수정하지 않았습니다. 

## 🔗 관련 이슈
#29 기능개발-비밀번호-재설정-기능-개발

