### PR TITLE
fix: SpringBatch 다른 entityManager 사용으로 인한 문제 수정

### DIFF
--- a/backend/src/main/java/force/ssafy/domain/solvedProblem/service/SolvedProblemSyncService.java
+++ b/backend/src/main/java/force/ssafy/domain/solvedProblem/service/SolvedProblemSyncService.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -39,7 +40,7 @@ public class SolvedProblemSyncService {
     @Value("${aws.lambda.baekjoon-crawler-url}")
     private String lambdaUrl;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRED)
     public SyncResultResponse syncSolvedProblems(String solvedAcId) {
 
         // 1. 회원 정보 조회


### PR DESCRIPTION


## 🔍 변경사항
<!-- 이번 PR에서 변경된 내용을 간략히 설명해주세요 -->

- 기존에는 spring의 안전우선동작으로 인해 리포지토리를 사용할 때마다 em을 새롭게 생성하여 사용
- `@Transactional` -> `@Transactional(propagation = Propagation.REQUIRED)`
- 명시적으로 사용하면 기존의 em을 재사용(같은 트랜잭션 내부에 있음)하여 수정내용이 반영됩니다.
## 💬리뷰 요구사항
<!-- 코드 리뷰시 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. -->

## 🔗 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 (ex. #123) -->
#107 
## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

