### PR TITLE
feat: 문제 필터링 기능 추가

### DIFF
--- a/backend/src/main/java/force/ssafy/domain/problem/controller/ProblemController.java
+++ b/backend/src/main/java/force/ssafy/domain/problem/controller/ProblemController.java
@@ -2,6 +2,7 @@ package force.ssafy.domain.problem.controller;
 
 import force.ssafy.domain.problem.dto.request.ProblemCreateRequest;
 import force.ssafy.domain.problem.dto.response.ProblemGetResponse;
+import force.ssafy.domain.problem.entity.ProblemTier;
 import force.ssafy.domain.problem.service.ProblemCrawlService;
 import force.ssafy.domain.problem.service.ProblemService;
 import lombok.RequiredArgsConstructor;
@@ -21,9 +22,12 @@ public class ProblemController {
 
     @GetMapping
     public ResponseEntity<Page<ProblemGetResponse>> findAll(
+            @RequestParam(required = false) Long problemNumber,
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) ProblemTier tier,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
-        return ResponseEntity.ok().body(problemService.findAll(PageRequest.of(page, size)));
+        return ResponseEntity.ok().body(problemService.findAll(problemNumber, title, tier, PageRequest.of(page, size)));
     }
 
     @PostMapping

--- a/backend/src/main/java/force/ssafy/domain/problem/repository/ProblemRepository.java
+++ b/backend/src/main/java/force/ssafy/domain/problem/repository/ProblemRepository.java
@@ -3,11 +3,12 @@ package force.ssafy.domain.problem.repository;
 import force.ssafy.domain.problem.entity.Problem;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProblemRepository extends JpaRepository<Problem, Long> {
+public interface ProblemRepository extends JpaRepository<Problem, Long>, JpaSpecificationExecutor<Problem> {
     Optional<Problem> findByProblemNumber(Long problemNumber);
 
     @Query(value = "SELECT problem_number FROM problem ORDER BY problem_number DESC LIMIT 1", nativeQuery = true)

--- a/backend/src/main/java/force/ssafy/domain/problem/service/ProblemService.java
+++ b/backend/src/main/java/force/ssafy/domain/problem/service/ProblemService.java
@@ -7,7 +7,9 @@ import force.ssafy.domain.algorithm.repository.AlgorithmRepository;
 import force.ssafy.domain.problem.dto.request.ProblemCreateRequest;
 import force.ssafy.domain.problem.dto.response.ProblemGetResponse;
 import force.ssafy.domain.problem.entity.Problem;
+import force.ssafy.domain.problem.entity.ProblemTier;
 import force.ssafy.domain.problem.repository.ProblemRepository;
+import force.ssafy.domain.problem.spec.ProblemSpecs;
 import force.ssafy.domain.problemAlgorithm.entity.ProblemAlgorithm;
 import force.ssafy.domain.problemAlgorithm.repository.ProblemAlgorithmRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -15,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,10 +36,15 @@ public class ProblemService {
 
     // ProblemCrawlService에서 ProblemService를 호출 중임
 
-    public Page<ProblemGetResponse> findAll(Pageable pageable) {
+    public Page<ProblemGetResponse> findAll(Long problemNumber, String title, ProblemTier tier, Pageable pageable) {
         log.info("selectAllProblems 호출");
 
-        Page<Problem> problems = problemRepository.findAll(pageable);
+        Specification<Problem> spec = Specification
+                .where(ProblemSpecs.containsTitle(title))
+                .and(ProblemSpecs.hasProblemNumber(problemNumber))
+                .and(ProblemSpecs.sameWithTier(tier));
+
+        Page<Problem> problems = problemRepository.findAll(spec, pageable);
         return problems.map(p -> {
             List<AlgorithmGetResponse> algorithmGetResponses = extractAlgorithmResponseFromEntity(p.getProblemAlgorithms());
             return ProblemGetResponse.of(p, algorithmGetResponses);

--- a/backend/src/main/java/force/ssafy/domain/problem/spec/ProblemSpecs.java
+++ b/backend/src/main/java/force/ssafy/domain/problem/spec/ProblemSpecs.java
@@ -1,0 +1,31 @@
+package force.ssafy.domain.problem.spec;
+
+import force.ssafy.domain.problem.entity.Problem;
+import force.ssafy.domain.problem.entity.ProblemTier;
+import org.springframework.data.jpa.domain.Specification;
+
+public class ProblemSpecs {
+
+    public static Specification<Problem> hasProblemNumber(Long problemNumber) {
+        return (root, query, cb) ->
+                problemNumber == null ?
+                        cb.conjunction() :
+                        cb.equal(root.get("problemNumber"), problemNumber);
+
+    }
+
+    public static Specification<Problem> containsTitle(String title) {
+        return (root, query, cb) ->
+                title == null ?
+                        cb.conjunction() :
+                        cb.like(root.get("title"), "%" + title + "%");
+    }
+
+    public static Specification<Problem> sameWithTier(ProblemTier tier) {
+        return (root, query, cb) ->
+                tier == null ?
+                        cb.conjunction() :
+                        cb.equal(root.get("tier"), tier);
+    }
+
+}


### PR DESCRIPTION
## 🔍 변경사항
BE에서 JpaSpecificationExecutor를 적용하여 필터링 조건을 설정했습니다.

필터링 기준
- 문제 이름
- 문제 번호
- 문제 티어(단축 티어로 검색 해야함, S1)

## 💬리뷰 요구사항
<!-- 코드 리뷰시 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. -->
현재 필터링 조건을 AND로 처리하고 있습니다. 제대로 적용했다고 생각하기는 하지만, 확신이 안 서서 다시 한 번 확인 받고 싶습니다.

필터링 조건을 AND 조건으로 하면 될까요?

## 🔗 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 (ex. #123) -->
#109

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
<img width="2100" height="1495" alt="image" src="https://github.com/user-attachments/assets/1381ac72-d7ea-4833-adf8-39e75af5e96d" />

