### PR TITLE
fix: 한국 시간대로 JVM이 동작하도록 Dockerfile에 변수추가

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,9 @@
 FROM openjdk:17-slim
 WORKDIR /app
 
+# 배포 환경에서 한국 시간대로 작동하도록 설정
+ENV TZ=Asia/Seoul
+
 # GitHub Actions가 빌드해둔 jar 파일을 복사
 COPY build/libs/*.jar app.jar
 


### PR DESCRIPTION
## 🔍 변경사항
<!-- 이번 PR에서 변경된 내용을 간략히 설명해주세요 -->
- JVM이 한국 시간대로 작동하지 않는 문제 식별하여 dockerfile에 시간대를 변수로 넣어줌으로서 ec2에서 서버가 한국 시간대로 인식
- LocalDateTime.now()를 사용 시 ec2 서버 시간말고 한국 시간을 사용할 것으로 예상
## 💬리뷰 요구사항
<!-- 코드 리뷰시 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. -->

## 🔗 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 (ex. #123) -->
#107 
## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

