### PR TITLE
106 기능개발 팀 가입 요청 및 승인 프런트 페이지 개발

### DIFF
--- a/backend/src/main/java/force/ssafy/domain/team/dto/response/TeamResponse.java
+++ b/backend/src/main/java/force/ssafy/domain/team/dto/response/TeamResponse.java
@@ -17,38 +17,37 @@ public class TeamResponse {
     private String name;
     private String description;
     private int memberCount;
-    //    private String leader;
+    private long leaderId;
     private LocalDateTime createdAt;
     private List<TeamMemberResponse> teamMembers;
-    private JoinStatus joinStatus;
 
     /**
      * 기존 메서드 - 팀 상세 조회용 (모든 멤버 정보)
      */
-    public static TeamResponse of(Team team, List<TeamMemberResponse> teamMembers, JoinStatus joinStatus) {
+    public static TeamResponse of(Team team, List<TeamMemberResponse> teamMembers) {
         return TeamResponse.builder()
                 .teamId(team.getId())
                 .name(team.getName())
                 .description(team.getDescription())
                 .memberCount(teamMembers.size())
+                .leaderId(team.getLeaderId())
                 .createdAt(team.getCreatedAt())
                 .teamMembers(teamMembers)
-                .joinStatus(joinStatus)
                 .build();
     }
 
     /**
      * 새로운 메서드 - 팀 목록 조회용 (미리보기 멤버 + 실제 멤버 수)
      */
-    public static TeamResponse ofWithActualCount(Team team, List<TeamMemberResponse> previewMembers, int actualMemberCount, JoinStatus joinStatus) {
+    public static TeamResponse ofWithActualCount(Team team, List<TeamMemberResponse> previewMembers, int actualMemberCount) {
         return TeamResponse.builder()
                 .teamId(team.getId())
                 .name(team.getName())
                 .description(team.getDescription())
                 .memberCount(actualMemberCount)  // 실제 멤버 수 사용
+                .leaderId(team.getLeaderId())
                 .createdAt(team.getCreatedAt())
                 .teamMembers(previewMembers)     // 미리보기 멤버 (최대 3명)
-                .joinStatus(joinStatus)
                 .build();
     }
 }

--- a/backend/src/main/java/force/ssafy/domain/team/dto/response/TeamResponse.java
+++ b/backend/src/main/java/force/ssafy/domain/team/dto/response/TeamResponse.java
@@ -1,6 +1,7 @@
 package force.ssafy.domain.team.dto.response;
 
 import force.ssafy.domain.team.entity.Team;
+import force.ssafy.domain.teamJoinRequest.entity.JoinStatus;
 import force.ssafy.domain.teamMember.dto.response.TeamMemberResponse;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,11 +20,12 @@ public class TeamResponse {
     //    private String leader;
     private LocalDateTime createdAt;
     private List<TeamMemberResponse> teamMembers;
+    private JoinStatus joinStatus;
 
     /**
      * 기존 메서드 - 팀 상세 조회용 (모든 멤버 정보)
      */
-    public static TeamResponse of(Team team, List<TeamMemberResponse> teamMembers) {
+    public static TeamResponse of(Team team, List<TeamMemberResponse> teamMembers, JoinStatus joinStatus) {
         return TeamResponse.builder()
                 .teamId(team.getId())
                 .name(team.getName())
@@ -31,13 +33,14 @@ public class TeamResponse {
                 .memberCount(teamMembers.size())
                 .createdAt(team.getCreatedAt())
                 .teamMembers(teamMembers)
+                .joinStatus(joinStatus)
                 .build();
     }
 
     /**
      * 새로운 메서드 - 팀 목록 조회용 (미리보기 멤버 + 실제 멤버 수)
      */
-    public static TeamResponse ofWithActualCount(Team team, List<TeamMemberResponse> previewMembers, int actualMemberCount) {
+    public static TeamResponse ofWithActualCount(Team team, List<TeamMemberResponse> previewMembers, int actualMemberCount, JoinStatus joinStatus) {
         return TeamResponse.builder()
                 .teamId(team.getId())
                 .name(team.getName())
@@ -45,6 +48,7 @@ public class TeamResponse {
                 .memberCount(actualMemberCount)  // 실제 멤버 수 사용
                 .createdAt(team.getCreatedAt())
                 .teamMembers(previewMembers)     // 미리보기 멤버 (최대 3명)
+                .joinStatus(joinStatus)
                 .build();
     }
 }

--- a/backend/src/main/java/force/ssafy/domain/team/entity/Team.java
+++ b/backend/src/main/java/force/ssafy/domain/team/entity/Team.java
@@ -1,5 +1,6 @@
 package force.ssafy.domain.team.entity;
 
+import force.ssafy.domain.member.entity.MemberRole;
 import force.ssafy.domain.teamMember.entity.TeamMember;
 import jakarta.persistence.*;
 import lombok.*;
@@ -40,5 +41,13 @@ public class Team {
     public void delete() {
         this.deleted = true;
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public Long getLeaderId() {
+        return this.teamMembers.stream()
+                .filter(tm -> tm.getRole() == MemberRole.LEADER)   // ① LEADER 비교
+                .findFirst()
+                .map(tm -> tm.getMember().getId())                 // ② member id 반환
+                .orElseThrow(() -> new IllegalStateException("리더 없음"));
     }
 }

--- a/backend/src/main/java/force/ssafy/domain/team/service/TeamService.java
+++ b/backend/src/main/java/force/ssafy/domain/team/service/TeamService.java
@@ -10,6 +10,7 @@ import force.ssafy.domain.team.dto.response.TeamResponse;
 import force.ssafy.domain.team.dto.response.TeamSimpleResponse;
 import force.ssafy.domain.team.entity.Team;
 import force.ssafy.domain.team.repository.TeamRepository;
+import force.ssafy.domain.teamJoinRequest.repository.TeamJoinRequestRepository;
 import force.ssafy.domain.teamMember.dto.TeamMemberDto;
 import force.ssafy.domain.teamMember.dto.response.TeamMemberResponse;
 import force.ssafy.domain.teamMember.entity.TeamMember;
@@ -35,6 +36,7 @@ public class TeamService {
     private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final MemberRepository memberRepository;
+    private final TeamJoinRequestRepository teamJoinRequestRepository;
 
     /**
      * 해당하는 teamId 에 대한 팀 정보와 소속 팀원들을 가져오는 메서드

--- a/backend/src/main/java/force/ssafy/domain/teamJoinRequest/controller/TeamJoinRequestController.java
+++ b/backend/src/main/java/force/ssafy/domain/teamJoinRequest/controller/TeamJoinRequestController.java
@@ -1,5 +1,6 @@
 package force.ssafy.domain.teamJoinRequest.controller;
 
+import force.ssafy.domain.teamJoinRequest.dto.MyTeamJoinRequestListDto;
 import force.ssafy.domain.teamJoinRequest.dto.TeamJoinRequestDto;
 import force.ssafy.domain.teamJoinRequest.service.TeamJoinRequestService;
 import force.ssafy.global.security.userdetails.CustomUserDetails;
@@ -100,6 +101,13 @@ public class TeamJoinRequestController {
 
         service.cancel(teamId, user.getMemberId());
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/join-requests/me")
+    public ResponseEntity<MyTeamJoinRequestListDto> myList(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        return ResponseEntity.ok(service.getMyRequestList(user.getMemberId()));
     }
 
 }

--- a/backend/src/main/java/force/ssafy/domain/teamJoinRequest/dto/MyTeamJoinRequestListDto.java
+++ b/backend/src/main/java/force/ssafy/domain/teamJoinRequest/dto/MyTeamJoinRequestListDto.java
@@ -1,0 +1,27 @@
+package force.ssafy.domain.teamJoinRequest.dto;
+
+import force.ssafy.domain.teamJoinRequest.entity.TeamJoinRequest;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Data
+@Builder
+public class MyTeamJoinRequestListDto {
+
+    private List<Long> teamList;
+
+    public static MyTeamJoinRequestListDto from(List<TeamJoinRequest> list) {
+        // 1) DTO에 담을 데이터 추출 ― 여기선 teamId만 모은다고 가정
+        List<Long> ids = list.stream()
+                .map(req -> req.getTeam().getId())
+                .toList();   // Java 16+ /  Stream API
+
+        // 2) DTO 인스턴스 생성
+        return MyTeamJoinRequestListDto.builder()
+                .teamList(ids)
+                .build();
+    }
+}

--- a/backend/src/main/java/force/ssafy/domain/teamJoinRequest/dto/TeamJoinRequestDto.java
+++ b/backend/src/main/java/force/ssafy/domain/teamJoinRequest/dto/TeamJoinRequestDto.java
@@ -8,17 +8,21 @@ import lombok.Data;
 @Builder
 public class TeamJoinRequestDto {
 
+    private Long requestId;
     private Long memberId;
     private Long teamId;
     private String name;
+    private String nickname;
     private String profileImageUrl;
 
     public static TeamJoinRequestDto from(TeamJoinRequest request) {
         return TeamJoinRequestDto.builder()
+                .requestId(request.getId())
                 .memberId(request.getRequester().getId())
                 .teamId(request.getTeam().getId())
                 .name(request.getRequester().getName())
-                .profileImageUrl(request.getRequester().getProfileImageUrl())
+                .nickname(request.getRequester().getSolvedAcId())
+            .profileImageUrl(request.getRequester().getProfileImageUrl())
                 .build();
     }
 }

--- a/backend/src/main/java/force/ssafy/domain/teamJoinRequest/repository/TeamJoinRequestRepository.java
+++ b/backend/src/main/java/force/ssafy/domain/teamJoinRequest/repository/TeamJoinRequestRepository.java
@@ -20,5 +20,11 @@ public interface TeamJoinRequestRepository extends JpaRepository<TeamJoinRequest
     );
 
     @EntityGraph(attributePaths = {"requester", "team"})
+    List<TeamJoinRequest> findAllByRequester_IdAndStatus(
+            Long requesterId,
+            JoinStatus status
+    );
+
+    @EntityGraph(attributePaths = {"requester", "team"})
     List<TeamJoinRequest> findByTeam_IdAndStatus(Long teamId, JoinStatus status);
 }

--- a/backend/src/main/java/force/ssafy/domain/teamJoinRequest/repository/TeamJoinRequestRepository.java
+++ b/backend/src/main/java/force/ssafy/domain/teamJoinRequest/repository/TeamJoinRequestRepository.java
@@ -20,6 +20,13 @@ public interface TeamJoinRequestRepository extends JpaRepository<TeamJoinRequest
     );
 
     @EntityGraph(attributePaths = {"requester", "team"})
+    Optional<TeamJoinRequest> findByIdAndTeam_IdAndStatus(
+        Long id,
+        Long teamId,
+        JoinStatus status
+    );
+
+    @EntityGraph(attributePaths = {"requester", "team"})
     List<TeamJoinRequest> findAllByRequester_IdAndStatus(
             Long requesterId,
             JoinStatus status

--- a/backend/src/main/java/force/ssafy/domain/teamJoinRequest/service/TeamJoinRequestService.java
+++ b/backend/src/main/java/force/ssafy/domain/teamJoinRequest/service/TeamJoinRequestService.java
@@ -100,7 +100,9 @@ public class TeamJoinRequestService {
                 .findByTeam_IdAndRequester_IdAndStatus(teamId, memberId, JoinStatus.PENDING)
                 .orElseThrow(() -> new EntityNotFoundException("대기 중인 요청이 없습니다."));
 
-        req.cancel();
+        // 취소 처리 말고 걍 삭제
+        teamJoinRequestRepository.delete(req);
+        // req.cancel();
     }
 
     public List<TeamJoinRequestDto> getRequestList(Long teamId, Long memberId) {

--- a/backend/src/main/java/force/ssafy/domain/teamJoinRequest/service/TeamJoinRequestService.java
+++ b/backend/src/main/java/force/ssafy/domain/teamJoinRequest/service/TeamJoinRequestService.java
@@ -5,6 +5,7 @@ import force.ssafy.domain.member.entity.MemberRole;
 import force.ssafy.domain.member.repository.MemberRepository;
 import force.ssafy.domain.team.entity.Team;
 import force.ssafy.domain.team.repository.TeamRepository;
+import force.ssafy.domain.teamJoinRequest.dto.MyTeamJoinRequestListDto;
 import force.ssafy.domain.teamJoinRequest.dto.TeamJoinRequestDto;
 import force.ssafy.domain.teamJoinRequest.entity.JoinStatus;
 import force.ssafy.domain.teamJoinRequest.entity.TeamJoinRequest;
@@ -14,6 +15,7 @@ import force.ssafy.domain.teamMember.repository.TeamMemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -125,5 +127,11 @@ public class TeamJoinRequestService {
         if (tm == null || tm.getRole() != MemberRole.LEADER) {
             throw new IllegalStateException("팀 리더만 가능한 접근입니다.");
         }
+    }
+
+    public MyTeamJoinRequestListDto getMyRequestList(Long memberId) {
+        List<TeamJoinRequest> list = teamJoinRequestRepository.findAllByRequester_IdAndStatus(memberId, JoinStatus.PENDING);
+
+        return MyTeamJoinRequestListDto.from(list);
     }
 }

--- a/backend/src/main/java/force/ssafy/domain/teamJoinRequest/service/TeamJoinRequestService.java
+++ b/backend/src/main/java/force/ssafy/domain/teamJoinRequest/service/TeamJoinRequestService.java
@@ -69,7 +69,7 @@ public class TeamJoinRequestService {
 
         checkTeamLeader(teamId, memberId);
 
-        TeamJoinRequest request = teamJoinRequestRepository.findByTeam_IdAndRequester_IdAndStatus(teamId, reqId, JoinStatus.PENDING)
+        TeamJoinRequest request = teamJoinRequestRepository.findByIdAndTeam_IdAndStatus(reqId, teamId, JoinStatus.PENDING)
                 .orElseThrow(() -> new EntityNotFoundException("해당 요청이 없습니다. "));
 
         request.approve();
@@ -84,10 +84,12 @@ public class TeamJoinRequestService {
 
         checkTeamLeader(teamId, memberId);
 
-        TeamJoinRequest request = teamJoinRequestRepository.findByTeam_IdAndRequester_IdAndStatus(teamId, reqId, JoinStatus.PENDING)
+        TeamJoinRequest request = teamJoinRequestRepository.findByIdAndTeam_IdAndStatus(reqId, teamId, JoinStatus.PENDING)
                 .orElseThrow(() -> new EntityNotFoundException("해당 요청이 없습니다. "));
 
-        request.reject();
+        // 삭제 처리 말고 걍 삭제
+        teamJoinRequestRepository.delete(request);
+        //request.reject();
     }
 
     @Transactional

--- a/frontend/src/api/teamApi.js
+++ b/frontend/src/api/teamApi.js
@@ -4,6 +4,25 @@ export const teamApi = {
   createTeam: (payload) => api.post('/teams', payload),
   getTeamById: (teamId) => api.get(`/teams/${teamId}`),
   fetchTeams: () => api.get('/teams'),
-  joinTeam: (teamId) => api.post(`/teams/${teamId}/join`),
+//  joinTeam: (teamId) => api.post(`/teams/${teamId}/join`),
   getTeamDetail: (teamId) => api.get(`/teams/${teamId}`),
+  /** 가입 요청 생성 */
+  requestJoin: teamId => api.post(`/teams/${teamId}/join-requests`),
+
+  /** 특정 팀의 가입 요청 목록 조회(리더 전용) */
+  fetchJoinRequests: teamId => api.get(`/teams/${teamId}/join-requests`),
+  
+  /** 가입 요청 단건 조회 */
+  getJoinRequest: (teamId, reqId) => 
+    api.get(`/teams/${teamId}/join-requests/${reqId}`),
+  
+  /** 가입 요청 승인 */
+  approveJoinRequest: (teamId, reqId) =>
+    api.patch(`/teams/${teamId}/join-requests/${reqId}/approve`),
+  
+  /** 가입 요청 거절 */
+  rejectJoinRequest: (teamId, reqId) => 
+    api.patch(`/teams/${teamId}/join-requests/${reqId}/reject`),
+  /** 내 팀 목록 조회 */
+  getMyTeams: () => api.get('/teams/me'),
 }

--- a/frontend/src/api/teamApi.js
+++ b/frontend/src/api/teamApi.js
@@ -23,6 +23,10 @@ export const teamApi = {
   /** 가입 요청 거절 */
   rejectJoinRequest: (teamId, reqId) => 
     api.patch(`/teams/${teamId}/join-requests/${reqId}/reject`),
+
+  cancelJoinRequest: (teamId) => 
+    api.delete(`/teams/${teamId}/join-requests/cancel`),
+
   /** 내 팀 목록 조회 */
   getMyTeams: () => api.get('/teams/me'),
   /** 내가 가입 신청한 팀 조회 */

--- a/frontend/src/api/teamApi.js
+++ b/frontend/src/api/teamApi.js
@@ -25,4 +25,6 @@ export const teamApi = {
     api.patch(`/teams/${teamId}/join-requests/${reqId}/reject`),
   /** 내 팀 목록 조회 */
   getMyTeams: () => api.get('/teams/me'),
+  /** 내가 가입 신청한 팀 조회 */
+  getmyTeamJoinRequestList: () => api.get('/teams/join-requests/me')
 }

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -140,6 +140,7 @@ export const useAuthStore = defineStore('auth', () => {
       if (response?.data) {
         user.value = {
           ...response.data,
+          memberId: response.data.id,
           isAuthenticated: true,
         }
       } else {

--- a/frontend/src/views/TeamDetailView.vue
+++ b/frontend/src/views/TeamDetailView.vue
@@ -127,28 +127,28 @@
 
           <div class="req-grid">
             <!-- 가입 요청 카드 (vertical) -->
-            <div v-for="req in joinRequests" :key="req.id" class="req-card">
+            <div v-for="req in joinRequests" :key="req.requestId" class="req-card" @click="goToProfile(req.nickname)">
               <!-- 아바타 -->
               <img
                 class="req-avatar"
-                :src="req.requester?.profileImage || defaultProfileImage"
-                :alt="req.requester?.name"
+                :src="req.profileImage || defaultProfileImage"
+                :alt="req.name"
                 @error="e => (e.target.src = defaultProfileImage)"
               />
 
               <!-- 이름 · 닉네임 -->
-              <h3 class="req-name">{{ req.requester?.name }}</h3>
-              <p  class="req-nickname">@{{ req.requester?.nickname }}</p>
+              <h3 class="req-name">{{ req.name }}</h3>
+              <p  class="req-nickname">@{{ req.nickname }}</p>
 
               <!-- 버튼 두 개를 가로로 -->
               <div class="req-buttons">
                 <!-- 승인 버튼 -->
-                <button class="btn-approve" @click="approve(req.id)">
+                <button class="btn-approve" @click.stop="approve(req.requestId)">
                   <font-awesome-icon :icon="['fas','check']" /> 승인
                 </button>
 
                 <!-- 거절 버튼 -->
-                <button class="btn-reject"  @click="reject(req.id)">
+                <button class="btn-reject"  @click.stop="reject(req.requestId)">
                   <font-awesome-icon :icon="['fas','times']" /> 거절
                 </button>
               </div>
@@ -287,14 +287,14 @@ const loadTeamDetail = async () => {
 
 const approve = async (reqId) => {
   await teamApi.approveJoinRequest(teamId.value, reqId)
-  joinRequests.value = joinRequests.value.filter(r => r.id !== reqId)
+  joinRequests.value = joinRequests.value.filter(r => r.requestId  !== reqId)
   // 멤버 수 증가 → 팀 정보 재조회
   await loadTeamDetail()
 }
 
 const reject = async (reqId) => {
   await teamApi.rejectJoinRequest(teamId.value, reqId)
-  joinRequests.value = joinRequests.value.filter(r => r.id !== reqId)
+  joinRequests.value = joinRequests.value.filter(r => r.requestId !== reqId)
 }
 
 // 팀 가입 처리

--- a/frontend/src/views/TeamDetailView.vue
+++ b/frontend/src/views/TeamDetailView.vue
@@ -23,6 +23,7 @@
               :src="team.profileImage || defaultProfileImage"
               :alt="team.name"
               class="team-image"
+              @error="onImgError"
             />
           </div>
 
@@ -43,31 +44,37 @@
 
             <!-- 팀 가입 버튼 -->
             <div class="team-actions">
+              <!-- 로그인 X -->
+              <router-link
+                v-if="!isLoggedIn"
+                to="/login"
+                class="btn btn-primary">
+                <font-awesome-icon :icon="['fas', 'user']" /> 로그인 후 가입
+              </router-link>
+
+              <!-- 가입 안했고 요청도 안 함 -->
               <button
-                v-if="!isJoined && isLoggedIn"
+                v-else-if="joinStatus === 'NONE'"
                 @click="handleJoinTeam"
                 :disabled="joiningTeam"
-                class="btn btn-primary"
-              >
+                class="btn btn-primary">
                 <template v-if="joiningTeam">
-                  <font-awesome-icon :icon="['fas', 'spinner']" spin />
-                  가입 중...
+                  <font-awesome-icon :icon="['fas', 'spinner']" spin /> 가입 중...
                 </template>
                 <template v-else>
-                  <font-awesome-icon :icon="['fas', 'plus']" />
-                  팀 가입하기
+                  <font-awesome-icon :icon="['fas', 'plus']" /> 팀 가입하기
                 </template>
               </button>
 
-              <span v-else-if="isJoined" class="joined-badge">
-                <font-awesome-icon :icon="['fas', 'check-circle']" />
-                가입된 팀
+              <!-- 요청 대기 중 -->
+              <span v-else-if="joinStatus === 'PENDING'" class="pending-badge">
+                <font-awesome-icon :icon="['fas', 'hourglass-half']" /> 요청 대기 중
               </span>
 
-              <router-link v-else-if="!isLoggedIn" to="/login" class="btn btn-primary">
-                <font-awesome-icon :icon="['fas', 'user']" />
-                로그인 후 가입
-              </router-link>
+              <!-- 이미 멤버 -->
+              <span v-else class="joined-badge">
+                <font-awesome-icon :icon="['fas', 'check-circle']" /> 가입된 팀
+              </span>
             </div>
           </div>
         </div>
@@ -106,6 +113,44 @@
               <div class="member-stats">
                 <!-- 여기에 멤버별 통계 정보가 들어갈 수 있습니다 -->
                 <span class="member-status">활성</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- 팀 멤버 목록 아래에 추가 -->
+        <div v-if="isLeader && joinRequests.length" class="join-req-section">
+          <h2 class="section-title">
+            <font-awesome-icon :icon="['fas', 'paper-plane']" />
+            가입 요청 ({{ joinRequests.length }}건)
+          </h2>
+
+          <div class="req-grid">
+            <!-- 가입 요청 카드 (vertical) -->
+            <div v-for="req in joinRequests" :key="req.id" class="req-card">
+              <!-- 아바타 -->
+              <img
+                class="req-avatar"
+                :src="req.requester?.profileImage || defaultProfileImage"
+                :alt="req.requester?.name"
+                @error="e => (e.target.src = defaultProfileImage)"
+              />
+
+              <!-- 이름 · 닉네임 -->
+              <h3 class="req-name">{{ req.requester?.name }}</h3>
+              <p  class="req-nickname">@{{ req.requester?.nickname }}</p>
+
+              <!-- 버튼 두 개를 가로로 -->
+              <div class="req-buttons">
+                <!-- 승인 버튼 -->
+                <button class="btn-approve" @click="approve(req.id)">
+                  <font-awesome-icon :icon="['fas','check']" /> 승인
+                </button>
+
+                <!-- 거절 버튼 -->
+                <button class="btn-reject"  @click="reject(req.id)">
+                  <font-awesome-icon :icon="['fas','times']" /> 거절
+                </button>
               </div>
             </div>
           </div>
@@ -162,9 +207,11 @@ import { useAuthStore } from '@/stores/auth'
 import { teamApi } from '@/api/teamApi'
 import defaultProfileImage from '@/mockdata/default_profile.png'
 
+const onImgError = (e) => { e.target.src = defaultProfileImage }
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
+const pendingIds = ref(new Set())
 
 // 라우트에서 teamId 가져오기
 const teamId = computed(() => route.params.teamId)
@@ -174,6 +221,11 @@ const team = ref(null)
 const loading = ref(true)
 const error = ref('')
 const joiningTeam = ref(false)
+
+const joinRequests = ref([])          // 대기 중 요청 목록
+const isLeader = computed(() =>
+  team.value?.leaderId === authStore.user?.memberId
+)
 
 // 계산된 속성
 const isLoggedIn = computed(() => authStore.isLoggedIn)
@@ -189,25 +241,60 @@ const isJoined = computed(() => {
 // 팀 상세 정보 로드
 const loadTeamDetail = async () => {
   loading.value = true
-  error.value = ''
+  error.value   = ''
 
   try {
-    console.log('팀 상세 정보 요청 중...', teamId.value)
-    const response = await teamApi.getTeamDetail(teamId.value)
-    team.value = response.data
-    console.log('팀 상세 정보 로드 성공:', team.value)
-  } catch (err) {
-    console.error('팀 상세 정보 로드 실패:', err)
-    if (err.response?.status === 404) {
-      error.value = '존재하지 않는 팀입니다.'
-    } else if (err.response?.status === 403) {
-      error.value = '팀 정보에 접근할 권한이 없습니다.'
-    } else {
-      error.value = err.response?.data?.message || '팀 정보를 불러오는데 실패했습니다.'
+    console.log('[LOAD] teamId =', teamId.value)
+
+    // ── 1) 팀 정보 호출 ───────────────────────────
+    const { data } = await teamApi.getTeamDetail(teamId.value)
+    team.value = data
+    console.log('[LOAD] team', data)
+
+    // ── 2) 내가 팀장인지 즉석 판단 ────────────────
+    const myId       = authStore.user?.memberId
+    const leaderId   = data.leaderId
+    const leaderMode = myId === leaderId
+
+    console.log('[CHECK] myId =', myId,
+                'leaderId =', leaderId,
+                '→ leaderMode =', leaderMode)
+
+    // ── 3) 팀장일 때 가입요청 목록 가져오기 ───────
+    if (leaderMode) {
+      const { data: reqList } =
+        await teamApi.fetchJoinRequests(teamId.value)
+
+      joinRequests.value = reqList
+      console.log('[JOIN‑REQ] count =', reqList.length, reqList)
     }
+
+    // ── 4) (선택) 내가 보낸 가입요청 목록 ─────────
+    if (isLoggedIn.value) {
+      const { data: myReq } = await teamApi.getmyTeamJoinRequestList()
+      pendingIds.value = new Set(myReq.teamList)
+      console.log('[MY‑REQ] teamList =', myReq.teamList)
+    }
+  } catch (err) {
+    console.error('[ERROR] loadTeamDetail →', err)
+    error.value =
+      err.response?.data?.message || '팀 정보를 불러오는데 실패했습니다.'
   } finally {
     loading.value = false
   }
+}
+
+
+const approve = async (reqId) => {
+  await teamApi.approveJoinRequest(teamId.value, reqId)
+  joinRequests.value = joinRequests.value.filter(r => r.id !== reqId)
+  // 멤버 수 증가 → 팀 정보 재조회
+  await loadTeamDetail()
+}
+
+const reject = async (reqId) => {
+  await teamApi.rejectJoinRequest(teamId.value, reqId)
+  joinRequests.value = joinRequests.value.filter(r => r.id !== reqId)
 }
 
 // 팀 가입 처리
@@ -221,9 +308,10 @@ const handleJoinTeam = async () => {
 
   try {
     console.log('팀 가입 요청 중...', teamId.value)
-    await teamApi.joinTeam(teamId.value)
+    await teamApi.requestJoin(teamId.value)
+    pendingIds.value.add(Number(teamId.value))
     console.log('팀 가입 성공')
-    alert('팀에 성공적으로 가입했습니다!')
+    alert('가입 요청이 전송되었습니다. 리더 승인을 기다려주세요!')
 
     // 팀 정보 다시 로드하여 멤버 목록 업데이트
     await loadTeamDetail()
@@ -272,6 +360,14 @@ onMounted(async () => {
   await authStore.initialize()
   await loadTeamDetail()
 })
+
+const joinStatus = computed(() => {
+  if (!isLoggedIn.value) return 'NONE'                      // 비로그인
+  if (isJoined.value)     return 'JOINED'                   // 이미 팀 멤버
+  if (pendingIds.value.has(+teamId.value)) return 'PENDING' // 승인 대기
+  return 'NONE'                                             // 그 밖의 경우
+})
+
 </script>
 
 <style scoped>
@@ -605,4 +701,115 @@ onMounted(async () => {
     grid-template-columns: 1fr;
   }
 }
+
+.pending-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.875rem 1.5rem;
+  background: #fff3cd;   /* 노란색 */
+  color: #856404;
+  border-radius: 8px;
+  font-weight: 500;
+  font-size: 1rem;
+}
+
+.join-req-section {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0,0,0,.08);
+  padding: 2rem;
+  margin-bottom: 2rem;
+}
+
+.req-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill,minmax(250px,1fr));
+  gap: 1rem;
+}
+
+.req-card {
+  display: flex;
+  flex-direction: column;   /* 세로 배치 */
+  align-items: center;
+  text-align: center;
+  gap: 0.6rem;
+  background: #f8f9fa;
+  padding: 1.5rem;
+  border-radius: 8px;
+  transition: all .2s;
+  cursor: default;
+  border: 2px solid transparent;
+}
+
+.req-card:hover {
+  background: #e9ecef;
+  border-color: var(--samsung-blue);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0,0,0,.1);
+}
+
+.req-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,.1);
+}
+
+.req-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.req-name      { font-size: 1.05rem; font-weight: 600; color:#333; margin:0; }
+.req-nickname  { font-size: .9rem;   color:#666;       margin:0; }
+
+.req-actions {
+  display: flex;
+  gap: .5rem;
+}
+
+.req-buttons {
+  display: flex;
+  gap: .5rem;           /* 버튼 사이 간격 */
+  margin-top: .8rem;    /* 아바타/텍스트와 간격 */
+}
+
+.btn-approve,
+.btn-reject {
+  flex: 1 1 80px;       /* 두 버튼이 같은 폭 */
+  justify-content: center;
+}
+
+.btn-approve,
+.btn-reject {
+  display: inline-flex;
+  align-items: center;
+  gap: .25rem;
+  padding: .4rem .7rem;
+  border-radius: 6px;
+  font-size: .85rem;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+}
+
+.btn-approve,
+.btn-reject {
+  display: inline-flex;       /* 아이콘+텍스트 한 줄 배치 */
+  align-items: center;
+  gap: .25rem;                /* 아이콘‑텍스트 사이 간격 */
+  white-space: nowrap;        /* 줄바꿈 방지 → “X 거절” */
+}
+
+
+.btn-approve { background: #28a745; color: #fff; }
+.btn-reject  { background: #dc3545; color: #fff; }
+
+.btn-approve:hover { background: #218838; }
+.btn-reject:hover  { background: #c82333; }
+
+
 </style>

--- a/frontend/src/views/TeamDetailView.vue
+++ b/frontend/src/views/TeamDetailView.vue
@@ -66,10 +66,20 @@
                 </template>
               </button>
 
-              <!-- 요청 대기 중 -->
-              <span v-else-if="joinStatus === 'PENDING'" class="pending-badge">
-                <font-awesome-icon :icon="['fas', 'hourglass-half']" /> 요청 대기 중
-              </span>
+              <button
+                v-else-if="joinStatus === 'PENDING'"
+                class="pending-badge"
+                @click="cancelMyRequest"
+                @mouseenter="pendingHover = true"
+                @mouseleave="pendingHover = false">
+            
+                <template v-if="!pendingHover">
+                  <font-awesome-icon :icon="['fas','hourglass-half']" /> 요청 대기 중
+                </template>
+                <template v-else>
+                  <font-awesome-icon :icon="['fas','times']" /> 신청 취소
+                </template>
+              </button>
 
               <!-- 이미 멤버 -->
               <span v-else class="joined-badge">
@@ -221,6 +231,21 @@ const team = ref(null)
 const loading = ref(true)
 const error = ref('')
 const joiningTeam = ref(false)
+
+const pendingHover = ref(false)
+
+// 내 가입 요청 취소
+const cancelMyRequest = async () => {
+  try {
+    await teamApi.cancelJoinRequest(teamId.value)
+    pendingIds.value.delete(+teamId.value)   // 컴퓨티드 joinStatus가 자동으로 'NONE' 으로
+    await loadTeamDetail()                   // 멤버 수 등 새로고침
+    alert('가입 요청을 취소했어요.')
+  } catch (e) {
+    console.error('[CANCEL] 실패', e)
+    alert(e.response?.data?.message || '요청 취소에 실패했습니다.')
+  }
+}
 
 const joinRequests = ref([])          // 대기 중 요청 목록
 const isLeader = computed(() =>
@@ -712,7 +737,13 @@ const joinStatus = computed(() => {
   border-radius: 8px;
   font-weight: 500;
   font-size: 1rem;
+  border:none;
 }
+
+.pending-badge:hover{
+  background:#f8d7da;color:#721c24;         /* hover → 붉은 톤 */
+}
+.pending-badge:disabled{opacity:.6;cursor:not-allowed}
 
 .join-req-section {
   background: white;

--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -1,587 +1,617 @@
-<!-- src/views/TeamView.vue -->
-<template>
-  <div class="team-view">
-    <div class="container">
-      <div class="page-header">
-        <h1>팀</h1>
-        <p>함께 성장할 팀을 찾아보세요</p>
-      </div>
-
-      <!-- 검색 및 필터 섹션 -->
-      <div class="search-filter-section">
-        <div class="search-container">
-          <input
-            v-model="searchQuery"
-            type="text"
-            placeholder="팀 이름이나 설명으로 검색..."
-            class="search-input"
-            @input="applyFilters"
-          />
-        </div>
-      </div>
-
-      <!-- 팀 목록 -->
-      <div class="teams-section">
-        <div v-if="loading" class="loading">
-          <font-awesome-icon :icon="['fas', 'spinner']" spin />
-          <span>팀을 불러오는 중...</span>
+  <!-- src/views/TeamView.vue -->
+  <template>
+    <div class="team-view">
+      <div class="container">
+        <div class="page-header">
+          <h1>팀</h1>
+          <p>함께 성장할 팀을 찾아보세요</p>
         </div>
 
-        <div v-else-if="teams.length === 0" class="no-teams">검색 조건에 맞는 팀이 없습니다.</div>
+        <!-- 검색 및 필터 섹션 -->
+        <div class="search-filter-section">
+          <div class="search-container">
+            <input
+              v-model="searchQuery"
+              type="text"
+              placeholder="팀 이름이나 설명으로 검색..."
+              class="search-input"
+              @input="applyFilters"
+            />
+          </div>
+        </div>
 
-        <div v-else class="teams-grid">
-          <div
-            v-for="team in teams"
-            :key="team.id"
-            class="team-card"
-            :class="{ joined: team.isJoined }"
-          >
-            <!-- 팀 카드 헤더 (클릭 가능) -->
-            <div class="team-header" @click="goToTeamDetail(team.id)">
-              <div class="team-avatar">
-                <img
-                  :src="team.profileImage || defaultProfileImage"
-                  :alt="team.name"
-                  class="team-image"
-                />
-              </div>
-              <div class="team-basic-info">
-                <h3 class="team-name">{{ team.name }}</h3>
-                <p class="team-description">{{ team.description }}</p>
-              </div>
-            </div>
+        <!-- 팀 목록 -->
+        <div class="teams-section">
+          <div v-if="loading" class="loading">
+            <font-awesome-icon :icon="['fas', 'spinner']" spin />
+            <span>팀을 불러오는 중...</span>
+          </div>
 
-            <!-- 팀 통계 정보 (클릭 가능) -->
-            <div class="team-stats" @click="goToTeamDetail(team.id)">
-              <div class="stat-item">
-                <span class="stat-label">멤버</span>
-                <span class="stat-value">{{ team.memberCount }}명</span>
-              </div>
-              <div class="stat-item">
-                <span class="stat-label">생성일</span>
-                <span class="stat-value">{{ formatDate(team.createdAt) }}</span>
-              </div>
-            </div>
+          <div v-else-if="teams.length === 0" class="no-teams">검색 조건에 맞는 팀이 없습니다.</div>
 
-            <!-- 팀 멤버 미리보기 (클릭 가능) -->
-            <div class="team-members-preview" @click="goToTeamDetail(team.id)">
-              <h4>멤버 미리보기</h4>
-              <div class="members-list">
-                <div
-                  v-for="member in team.teamMembers.slice(0, 3)"
-                  :key="member.id"
-                  class="member-item"
-                >
+          <div v-else class="teams-grid">
+            <div
+              v-for="team in teams"
+              :key="team.id"
+              class="team-card"
+              :class="{ joined: team.isJoined }"
+            >
+              <!-- 팀 카드 헤더 (클릭 가능) -->
+              <div class="team-header" @click="goToTeamDetail(team.id)">
+                <div class="team-avatar">
                   <img
-                    :src="member.profileImage || defaultProfileImage"
-                    :alt="member.name"
-                    class="member-avatar"
+                    :src="team.profileImage || defaultProfileImage"
+                    :alt="team.name"
+                    class="team-image"
                   />
-                  <span class="member-name">{{ member.nickname }}</span>
                 </div>
-                <div v-if="team.teamMembers.length > 3" class="more-members">
-                  +{{ team.teamMembers.length - 3 }}명 더
-                </div>
-                <div v-if="team.teamMembers.length === 0" class="no-members-preview">
-                  아직 멤버가 없습니다
+                <div class="team-basic-info">
+                  <h3 class="team-name">{{ team.name }}</h3>
+                  <p class="team-description">{{ team.description }}</p>
                 </div>
               </div>
-            </div>
 
-            <!-- 팀 액션 버튼들 (클릭 이벤트 전파 방지) -->
-            <div class="team-actions">
-              <button @click.stop="goToTeamDetail(team.id)" class="btn btn-outline">
-                <font-awesome-icon :icon="['fas', 'eye']" />
-                상세보기
-              </button>
+              <!-- 팀 통계 정보 (클릭 가능) -->
+              <div class="team-stats" @click="goToTeamDetail(team.id)">
+                <div class="stat-item">
+                  <span class="stat-label">멤버</span>
+                  <span class="stat-value">{{ team.memberCount }}명</span>
+                </div>
+                <div class="stat-item">
+                  <span class="stat-label">생성일</span>
+                  <span class="stat-value">{{ formatDate(team.createdAt) }}</span>
+                </div>
+              </div>
 
-              <button
-                v-if="!team.isJoined"
-                @click.stop="handleJoinTeam(team)"
-                :disabled="joiningTeamId === team.id"
-                class="btn btn-primary"
-              >
-                <template v-if="joiningTeamId === team.id">
-                  <font-awesome-icon :icon="['fas', 'spinner']" spin />
-                  가입 중...
-                </template>
-                <template v-else>
-                  <font-awesome-icon :icon="['fas', 'plus']" />
-                  팀 가입
-                </template>
-              </button>
+              <!-- 팀 멤버 미리보기 (클릭 가능) -->
+              <div class="team-members-preview" @click="goToTeamDetail(team.id)">
+                <h4>멤버 미리보기</h4>
+                <div class="members-list">
+                  <div
+                    v-for="member in team.teamMembers.slice(0, 3)"
+                    :key="member.id"
+                    class="member-item"
+                  >
+                    <img
+                      :src="member.profileImage || defaultProfileImage"
+                      :alt="member.name"
+                      class="member-avatar"
+                    />
+                    <span class="member-name">{{ member.nickname }}</span>
+                  </div>
+                  <div v-if="team.teamMembers.length > 3" class="more-members">
+                    +{{ team.teamMembers.length - 3 }}명 더
+                  </div>
+                  <div v-if="team.teamMembers.length === 0" class="no-members-preview">
+                    아직 멤버가 없습니다
+                  </div>
+                </div>
+              </div>
 
-              <span v-else class="joined-badge">
-                <font-awesome-icon :icon="['fas', 'check-circle']" />
-                가입된 팀
-              </span>
-            </div>
+              <!-- 팀 액션 버튼들 -->
+              <div class="team-actions">
+                <!-- 아직 요청 안 한 상태 -->
+                <button
+                  v-if="team.joinStatus === 'NONE'"
+                  @click.stop="handleJoinTeam(team)"
+                  :disabled="joiningTeamId === team.id"
+                  class="btn btn-primary"
+                >
+                  <template v-if="joiningTeamId === team.id">
+                    <font-awesome-icon :icon="['fas', 'spinner']" spin />
+                    요청 중...
+                  </template>
+                  <template v-else>
+                    <font-awesome-icon :icon="['fas', 'plus']" />
+                    팀 가입 요청
+                  </template>
+                </button>
 
-            <!-- 팀 메타 정보 -->
-            <div class="team-meta" @click="goToTeamDetail(team.id)">
-              <span class="created-date">{{ formatDate(team.createdAt) }} 생성</span>
+                <!-- 요청 보낸 뒤 승인 대기 -->
+                <span v-else-if="team.joinStatus === 'PENDING'" class="pending-badge">
+                  <font-awesome-icon :icon="['fas', 'hourglass-half']" />
+                  요청 대기 중
+                </span>
+
+                <!-- 이미 팀 멤버 -->
+                <span v-else class="joined-badge">
+                  <font-awesome-icon :icon="['fas', 'check-circle']" />
+                  가입된 팀
+                </span>
+
+                <!-- 상세 보기 버튼은 그대로 -->
+                <button @click.stop="goToTeamDetail(team.id)" class="btn btn-outline">
+                  <font-awesome-icon :icon="['fas', 'eye']" />
+                  상세보기
+                </button>
+              </div>
+
+              <!-- 팀 메타 정보 -->
+              <div class="team-meta" @click="goToTeamDetail(team.id)">
+                <span class="created-date">{{ formatDate(team.createdAt) }} 생성</span>
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <!-- 팀 생성 버튼 -->
-      <div class="create-team-section">
-        <router-link to="/teams/create" class="btn btn-secondary">
-          <font-awesome-icon :icon="['fas', 'plus']" /> 새 팀 만들기
-        </router-link>
+        <!-- 팀 생성 버튼 -->
+        <div class="create-team-section">
+          <router-link to="/teams/create" class="btn btn-secondary">
+            <font-awesome-icon :icon="['fas', 'plus']" /> 새 팀 만들기
+          </router-link>
+        </div>
       </div>
     </div>
-  </div>
-</template>
+  </template>
 
-<script setup>
-import { ref, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
-import { teamApi } from '@/api/teamApi'
-import { useAuthStore } from '@/stores/auth'
-import defaultProfileImage from '@/mockdata/default_profile.png'
+  <script setup>
+  import { ref, onMounted } from 'vue'
+  import { useRouter } from 'vue-router'
+  import { teamApi } from '@/api/teamApi'
+  import { useAuthStore } from '@/stores/auth'
+  import defaultProfileImage from '@/mockdata/default_profile.png'
 
-const teams = ref([])
-const loading = ref(true)
-const searchQuery = ref('')
-const joiningTeamId = ref(null)
+  const teams = ref([])
+  const loading = ref(true)
+  const searchQuery = ref('')
+  const joiningTeamId = ref(null)
 
-// Pinia auth store
-const auth = useAuthStore()
-const router = useRouter()
+  // Pinia auth store
+  const auth = useAuthStore()
+  const router = useRouter()
 
-// 날짜 포맷팅
-const formatDate = (dateString) => {
-  const date = new Date(dateString)
-  return date.toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
-}
-
-// 팀 목록 로드
-const loadTeams = async () => {
-  loading.value = true
-  try {
-    const res = await teamApi.fetchTeams()
-    // 백엔드 API 응답 구조에 맞게 수정
-    const teamsData = res.data.teams || []
-
-    teams.value = teamsData
-      .filter((t) => t.name.toLowerCase().includes(searchQuery.value.toLowerCase()))
-      .map((t) => ({
-        id: t.teamId,
-        name: t.name,
-        description: t.description,
-        memberCount: t.memberCount,
-        createdAt: t.createdAt,
-        teamMembers: t.teamMembers || [],
-        profileImage: t.profileImage,
-        isJoined: false, // 필요시 로직 수정
-      }))
-  } catch (error) {
-    console.error('팀 로드 실패:', error)
-    teams.value = []
-  } finally {
-    loading.value = false
-  }
-}
-
-// 검색 필터 적용
-const applyFilters = () => {
-  loadTeams()
-}
-
-// 팀 상세 페이지로 이동
-const goToTeamDetail = (teamId) => {
-  router.push(`/teams/${teamId}`)
-}
-
-// 팀 가입 처리
-const handleJoinTeam = async (team) => {
-  // 1) 로그인 여부 확인
-  if (!auth.isLoggedIn) {
-    // 로그인 되어 있지 않으면 로그인 페이지로 리다이렉트
-    router.push({ name: 'login', query: { redirect: router.currentRoute.value.fullPath } })
-    return
+  // 날짜 포맷팅
+  const formatDate = (dateString) => {
+    const date = new Date(dateString)
+    return date.toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
   }
 
-  // 2) 가입 요청
-  joiningTeamId.value = team.id
-  try {
-    // 백엔드: POST /api/v1/teams/{teamId}/join
-    await teamApi.joinTeam(team.id)
+  // 팀 목록 로드
+  const loadTeams = async () => {
+    loading.value = true
+    try {
+      // ① 전체 팀 + ② 내가 가입한 팀 병렬 호출
+      const [allTeamsRes, myTeamsRes] = await Promise.all([
+        teamApi.fetchTeams(),
+        teamApi.getMyTeams(),
+      ])
+
+      // 내가 가입한 팀 id 집합
+      const myTeamIds = new Set(myTeamsRes.data.teams.map(t => t.id))
+
+      // 검색어 필터 + joinStatus 주입
+      teams.value = allTeamsRes.data.teams
+        .filter(t =>
+          t.name.toLowerCase().includes(searchQuery.value.toLowerCase())
+        )
+        .map(t => ({
+          id: t.teamId,
+          name: t.name,
+          description: t.description,
+          memberCount: t.memberCount,
+          createdAt: t.createdAt,
+          teamMembers: t.teamMembers || [],
+          profileImage: t.profileImage,
+          joinStatus: myTeamIds.has(t.teamId) ? 'JOINED' : 'NONE',
+        }))
+    } catch (e) {
+      console.error('팀 로드 실패:', e)
+      teams.value = []
+    } finally {
+      loading.value = false
+    }
+  }
+
+
+  // 검색 필터 적용
+  const applyFilters = () => {
+    loadTeams()
+  }
+
+  // 팀 상세 페이지로 이동
+  const goToTeamDetail = (teamId) => {
+    router.push(`/teams/${teamId}`)
+  }
+
+  // 팀 가입 처리
+  const handleJoinTeam = async team => {
+    if (!auth.isLoggedIn) {
+      router.push({ name: 'login', query: { redirect: router.currentRoute.value.fullPath } })
+      return
+    }
+
+    joiningTeamId.value = team.id
+    try {
+      await teamApi.requestJoin(team.id)          // ★ 새 엔드포인트
+      // UX: 응답이 OK면 바로 상태만 업데이트
+      team.joinStatus = 'PENDING'
+      alert('가입 요청이 전송되었습니다. 리더 승인을 기다려주세요!')
+    } catch (e) {
+      console.error('팀 가입 요청 실패:', e)
+      alert(e.response?.data?.message || '팀 가입 요청에 실패했습니다.')
+    } finally {
+      joiningTeamId.value = null
+    }
+  }
+
+  onMounted(async () => {
+    await auth.initialize()
     await loadTeams()
-    alert('팀에 성공적으로 가입했습니다!')
-  } catch (error) {
-    console.error('팀 가입 실패:', error)
-    alert(error.response?.data?.message || '팀 가입에 실패했습니다.')
-  } finally {
-    joiningTeamId.value = null
-  }
-}
+  })
+  </script>
 
-onMounted(async () => {
-  await auth.initialize()
-  await loadTeams()
-})
-</script>
-
-<style scoped>
-.team-view {
-  min-height: calc(100vh - 64px);
-  background-color: #f9f9f9;
-  padding: 2rem 0;
-}
-
-.container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 2rem;
-}
-
-.page-header {
-  text-align: center;
-  margin-bottom: 3rem;
-}
-
-.page-header h1 {
-  font-size: 2.5rem;
-  margin-bottom: 0.5rem;
-  color: #333;
-}
-
-.page-header p {
-  font-size: 1.1rem;
-  color: #666;
-}
-
-/* 검색 및 필터 섹션 */
-.search-filter-section {
-  background: white;
-  padding: 1.5rem;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  margin-bottom: 2rem;
-}
-
-.search-container {
-  margin-bottom: 1rem;
-}
-
-.search-input {
-  width: 100%;
-  padding: 0.75rem 1rem;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  font-size: 1rem;
-}
-
-.search-input:focus {
-  outline: none;
-  border-color: var(--samsung-blue);
-  box-shadow: 0 0 0 2px var(--samsung-blue-alpha);
-}
-
-/* 팀 목록 */
-.teams-section {
-  margin-bottom: 3rem;
-}
-
-.loading {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 3rem;
-  color: #666;
-  gap: 1rem;
-}
-
-.no-teams {
-  text-align: center;
-  padding: 3rem;
-  color: #666;
-  font-size: 1.1rem;
-}
-
-.teams-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-  gap: 1.5rem;
-}
-
-.team-card {
-  background: white;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  transition:
-    transform 0.2s,
-    box-shadow 0.2s;
-  border-left: 4px solid transparent;
-  overflow: hidden;
-}
-
-.team-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-}
-
-.team-card.joined {
-  border-left-color: #28a745;
-  background: linear-gradient(135deg, rgba(40, 167, 69, 0.05) 0%, white 100%);
-}
-
-/* 팀 헤더 */
-.team-header {
-  display: flex;
-  gap: 1rem;
-  padding: 1.5rem;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.team-header:hover {
-  background-color: #f8f9fa;
-}
-
-.team-avatar {
-  flex-shrink: 0;
-}
-
-.team-image {
-  width: 60px;
-  height: 60px;
-  border-radius: 8px;
-  object-fit: cover;
-  border: 2px solid #eee;
-}
-
-.team-basic-info {
-  flex: 1;
-  min-width: 0;
-}
-
-.team-name {
-  font-size: 1.3rem;
-  color: #333;
-  margin: 0 0 0.5rem 0;
-  font-weight: 600;
-}
-
-.team-description {
-  color: #666;
-  margin: 0;
-  line-height: 1.5;
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-
-/* 팀 통계 */
-.team-stats {
-  display: flex;
-  justify-content: space-around;
-  padding: 1rem 1.5rem;
-  background: #f8f9fa;
-  border-top: 1px solid #eee;
-  border-bottom: 1px solid #eee;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.team-stats:hover {
-  background-color: #e9ecef;
-}
-
-.stat-item {
-  text-align: center;
-}
-
-.stat-label {
-  display: block;
-  font-size: 0.8rem;
-  color: #666;
-  margin-bottom: 0.25rem;
-}
-
-.stat-value {
-  display: block;
-  font-weight: 600;
-  color: var(--samsung-blue);
-}
-
-/* 팀 멤버 미리보기 */
-.team-members-preview {
-  padding: 1rem 1.5rem;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.team-members-preview:hover {
-  background-color: #f8f9fa;
-}
-
-.team-members-preview h4 {
-  font-size: 1rem;
-  margin-bottom: 0.75rem;
-  color: #333;
-}
-
-.members-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.member-item {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.member-avatar {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 2px solid #eee;
-}
-
-.member-name {
-  font-weight: 500;
-  font-size: 0.9rem;
-  color: #333;
-}
-
-.more-members,
-.no-members-preview {
-  color: #666;
-  font-size: 0.9rem;
-  text-align: center;
-  padding: 0.5rem;
-  background-color: #f1f3f5;
-  border-radius: 4px;
-  margin-top: 0.5rem;
-}
-
-/* 팀 액션 */
-.team-actions {
-  padding: 1rem 1.5rem;
-  display: flex;
-  gap: 0.75rem;
-  justify-content: center;
-  border-top: 1px solid #eee;
-}
-
-.btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1rem;
-  border-radius: 4px;
-  text-decoration: none;
-  font-weight: 500;
-  transition: all 0.2s;
-  border: none;
-  cursor: pointer;
-  font-size: 0.9rem;
-  flex: 1;
-  justify-content: center;
-}
-
-.btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.btn-primary {
-  background-color: var(--samsung-blue);
-  color: white;
-}
-
-.btn-primary:hover:not(:disabled) {
-  background-color: var(--samsung-blue-dark);
-  transform: translateY(-1px);
-}
-
-.btn-outline {
-  background-color: transparent;
-  color: var(--samsung-blue);
-  border: 1px solid var(--samsung-blue);
-}
-
-.btn-outline:hover {
-  background-color: var(--samsung-blue-alpha);
-}
-
-.btn-secondary {
-  background-color: #f8f9fa;
-  color: #333;
-  border: 1px solid #dee2e6;
-}
-
-.btn-secondary:hover {
-  background-color: #e9ecef;
-}
-
-.joined-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1rem;
-  background: #d4edda;
-  color: #155724;
-  border-radius: 4px;
-  font-weight: 500;
-  font-size: 0.9rem;
-  flex: 1;
-  justify-content: center;
-}
-
-/* 팀 메타 정보 */
-.team-meta {
-  padding: 0.75rem 1.5rem;
-  text-align: center;
-  color: #666;
-  font-size: 0.8rem;
-  background-color: #fafafa;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.team-meta:hover {
-  background-color: #f1f3f5;
-}
-
-.create-team-section {
-  text-align: center;
-  margin-top: 2rem;
-}
-
-/* 반응형 디자인 */
-@media (max-width: 768px) {
-  .teams-grid {
-    grid-template-columns: 1fr;
+  <style scoped>
+  .team-view {
+    min-height: calc(100vh - 64px);
+    background-color: #f9f9f9;
+    padding: 2rem 0;
   }
 
-  .team-header {
-    flex-direction: column;
+  .container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 2rem;
+  }
+
+  .page-header {
     text-align: center;
+    margin-bottom: 3rem;
+  }
+
+  .page-header h1 {
+    font-size: 2.5rem;
+    margin-bottom: 0.5rem;
+    color: #333;
+  }
+
+  .page-header p {
+    font-size: 1.1rem;
+    color: #666;
+  }
+
+  /* 검색 및 필터 섹션 */
+  .search-filter-section {
+    background: white;
+    padding: 1.5rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    margin-bottom: 2rem;
+  }
+
+  .search-container {
+    margin-bottom: 1rem;
+  }
+
+  .search-input {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 1rem;
+  }
+
+  .search-input:focus {
+    outline: none;
+    border-color: var(--samsung-blue);
+    box-shadow: 0 0 0 2px var(--samsung-blue-alpha);
+  }
+
+  /* 팀 목록 */
+  .teams-section {
+    margin-bottom: 3rem;
+  }
+
+  .loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 3rem;
+    color: #666;
     gap: 1rem;
   }
 
+  .no-teams {
+    text-align: center;
+    padding: 3rem;
+    color: #666;
+    font-size: 1.1rem;
+  }
+
+  .teams-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .team-card {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    transition:
+      transform 0.2s,
+      box-shadow 0.2s;
+    border-left: 4px solid transparent;
+    overflow: hidden;
+  }
+
+  .team-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  }
+
+  .team-card.joined {
+    border-left-color: #28a745;
+    background: linear-gradient(135deg, rgba(40, 167, 69, 0.05) 0%, white 100%);
+  }
+
+  /* 팀 헤더 */
+  .team-header {
+    display: flex;
+    gap: 1rem;
+    padding: 1.5rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+  }
+
+  .team-header:hover {
+    background-color: #f8f9fa;
+  }
+
+  .team-avatar {
+    flex-shrink: 0;
+  }
+
+  .team-image {
+    width: 60px;
+    height: 60px;
+    border-radius: 8px;
+    object-fit: cover;
+    border: 2px solid #eee;
+  }
+
+  .team-basic-info {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .team-name {
+    font-size: 1.3rem;
+    color: #333;
+    margin: 0 0 0.5rem 0;
+    font-weight: 600;
+  }
+
+  .team-description {
+    color: #666;
+    margin: 0;
+    line-height: 1.5;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+
+  /* 팀 통계 */
   .team-stats {
-    flex-direction: column;
-    gap: 0.75rem;
+    display: flex;
+    justify-content: space-around;
+    padding: 1rem 1.5rem;
+    background: #f8f9fa;
+    border-top: 1px solid #eee;
+    border-bottom: 1px solid #eee;
+    cursor: pointer;
+    transition: background-color 0.2s;
+  }
+
+  .team-stats:hover {
+    background-color: #e9ecef;
+  }
+
+  .stat-item {
     text-align: center;
   }
 
-  .team-actions {
+  .stat-label {
+    display: block;
+    font-size: 0.8rem;
+    color: #666;
+    margin-bottom: 0.25rem;
+  }
+
+  .stat-value {
+    display: block;
+    font-weight: 600;
+    color: var(--samsung-blue);
+  }
+
+  /* 팀 멤버 미리보기 */
+  .team-members-preview {
+    padding: 1rem 1.5rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+  }
+
+  .team-members-preview:hover {
+    background-color: #f8f9fa;
+  }
+
+  .team-members-preview h4 {
+    font-size: 1rem;
+    margin-bottom: 0.75rem;
+    color: #333;
+  }
+
+  .members-list {
+    display: flex;
     flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .member-item {
+    display: flex;
+    align-items: center;
     gap: 0.75rem;
   }
-}
-</style>
+
+  .member-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid #eee;
+  }
+
+  .member-name {
+    font-weight: 500;
+    font-size: 0.9rem;
+    color: #333;
+  }
+
+  .more-members,
+  .no-members-preview {
+    color: #666;
+    font-size: 0.9rem;
+    text-align: center;
+    padding: 0.5rem;
+    background-color: #f1f3f5;
+    border-radius: 4px;
+    margin-top: 0.5rem;
+  }
+
+  /* 팀 액션 */
+  .team-actions {
+    padding: 1rem 1.5rem;
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    border-top: 1px solid #eee;
+  }
+
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1rem;
+    border-radius: 4px;
+    text-decoration: none;
+    font-weight: 500;
+    transition: all 0.2s;
+    border: none;
+    cursor: pointer;
+    font-size: 0.9rem;
+    flex: 1;
+    justify-content: center;
+  }
+
+  .btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .btn-primary {
+    background-color: var(--samsung-blue);
+    color: white;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background-color: var(--samsung-blue-dark);
+    transform: translateY(-1px);
+  }
+
+  .btn-outline {
+    background-color: transparent;
+    color: var(--samsung-blue);
+    border: 1px solid var(--samsung-blue);
+  }
+
+  .btn-outline:hover {
+    background-color: var(--samsung-blue-alpha);
+  }
+
+  .btn-secondary {
+    background-color: #f8f9fa;
+    color: #333;
+    border: 1px solid #dee2e6;
+  }
+
+  .btn-secondary:hover {
+    background-color: #e9ecef;
+  }
+
+  .joined-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1rem;
+    background: #d4edda;
+    color: #155724;
+    border-radius: 4px;
+    font-weight: 500;
+    font-size: 0.9rem;
+    flex: 1;
+    justify-content: center;
+  }
+
+  /* 팀 메타 정보 */
+  .team-meta {
+    padding: 0.75rem 1.5rem;
+    text-align: center;
+    color: #666;
+    font-size: 0.8rem;
+    background-color: #fafafa;
+    cursor: pointer;
+    transition: background-color 0.2s;
+  }
+
+  .team-meta:hover {
+    background-color: #f1f3f5;
+  }
+
+  .create-team-section {
+    text-align: center;
+    margin-top: 2rem;
+  }
+
+  /* 반응형 디자인 */
+  @media (max-width: 768px) {
+    .teams-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .team-header {
+      flex-direction: column;
+      text-align: center;
+      gap: 1rem;
+    }
+
+    .team-stats {
+      flex-direction: column;
+      gap: 0.75rem;
+      text-align: center;
+    }
+
+    .team-actions {
+      flex-direction: column;
+      gap: 0.75rem;
+    }  
+  }
+
+  .pending-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1rem;
+    background: #fff3cd;
+    color: #856404;
+    border-radius: 4px;
+    font-weight: 500;
+    font-size: 0.9rem;
+    flex: 1;
+    justify-content: center;
+  }
+
+  </style>

--- a/frontend/src/views/TeamView.vue
+++ b/frontend/src/views/TeamView.vue
@@ -174,21 +174,34 @@
   const loadTeams = async () => {
     loading.value = true
     try {
+      
+      // 공통 호출 = 전체 팀
+      const allTeamsReq = teamApi.fetchTeams()
+
+      // 로그인 여부에 따라 추가 호출 결정
+      const myTeamsReq  = auth.isLoggedIn ? teamApi.getMyTeams()             : Promise.resolve({ data:{ teams: [] }})
+      const pendingReq  = auth.isLoggedIn ? teamApi.getmyTeamJoinRequestList(): Promise.resolve({ data:{ teamList: [] }})
+
       // ① 전체 팀 + ② 내가 가입한 팀 병렬 호출
-      const [allTeamsRes, myTeamsRes] = await Promise.all([
-        teamApi.fetchTeams(),
-        teamApi.getMyTeams(),
-      ])
+      const [allTeamsRes, myTeamsRes, pendingRes] =
+      await Promise.all([allTeamsReq, myTeamsReq, pendingReq])
 
       // 내가 가입한 팀 id 집합
       const myTeamIds = new Set(myTeamsRes.data.teams.map(t => t.id))
+      // 내가 가입 신청한 팀 id 집합
+      const pendingIds  = new Set(pendingRes.data.teamList)
 
       // 검색어 필터 + joinStatus 주입
       teams.value = allTeamsRes.data.teams
-        .filter(t =>
-          t.name.toLowerCase().includes(searchQuery.value.toLowerCase())
-        )
-        .map(t => ({
+      .filter(t =>
+        t.name.toLowerCase().includes(searchQuery.value.toLowerCase())
+      )
+      .map(t => {
+        let status = 'NONE'
+        if (myTeamIds.has(t.teamId))      status = 'JOINED'
+        else if (pendingIds.has(t.teamId)) status = 'PENDING'
+
+        return {
           id: t.teamId,
           name: t.name,
           description: t.description,
@@ -196,8 +209,9 @@
           createdAt: t.createdAt,
           teamMembers: t.teamMembers || [],
           profileImage: t.profileImage,
-          joinStatus: myTeamIds.has(t.teamId) ? 'JOINED' : 'NONE',
-        }))
+          joinStatus: status,
+        }
+      })
     } catch (e) {
       console.error('팀 로드 실패:', e)
       teams.value = []
@@ -227,6 +241,7 @@
     joiningTeamId.value = team.id
     try {
       await teamApi.requestJoin(team.id)          // ★ 새 엔드포인트
+      team.joinStatus = 'PENDING'
       // UX: 응답이 OK면 바로 상태만 업데이트
       team.joinStatus = 'PENDING'
       alert('가입 요청이 전송되었습니다. 리더 승인을 기다려주세요!')


### PR DESCRIPTION
## 🔍 변경사항
- 팀 생성시 본인이 리더가 됨
- 팀 가입 요청을 하면 요청 대기중 상태가 됨
- 팀장이 팀 상세 페이지에 들어가면, 팀 가입 신청 목록이 조회됨
- 가입을 승인하면 팀원이 됨
- 가입을 취소하면 해당 멤버는 다시 가입을 신청할 수 있음
- 팀 상세 페이지에 들어가면 팀 가입 요청을 취소할 수 있음

## 💬리뷰 요구사항
- 로컬에서 테스트하느라 팀 가입 요청 거절시 당사자의 반응을 확인하지 못했습니다. 근데 뭐 잘 돌아갈 듯 합니다. 

## 🔗 관련 이슈
#106 

## 📸 스크린샷
<img width="2354" height="1054" alt="image" src="https://github.com/user-attachments/assets/ddf180fb-8d26-44e7-8ddd-305c2b0c7711" />

<img width="2376" height="732" alt="image" src="https://github.com/user-attachments/assets/03e371d5-7955-4181-9e69-f84b27f4b655" />

<img width="2355" height="745" alt="image" src="https://github.com/user-attachments/assets/0cac3f13-fc91-4a3e-84cd-e11c6f519299" />


<img width="2354" height="1312" alt="image" src="https://github.com/user-attachments/assets/5f7e5d07-eccc-4134-9b83-c3ae73848b86" />
