### PR TITLE
118 [기능개발] : 해결한 문제 동기화 기능 비동기로 개선하기

### DIFF
--- a/backend/src/main/java/force/ssafy/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/force/ssafy/domain/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import force.ssafy.domain.auth.exception.AuthenticationException;
 import force.ssafy.domain.auth.service.AuthService;
 import force.ssafy.domain.member.dto.response.MemberDto;
 import force.ssafy.domain.member.entity.Member;
+import force.ssafy.domain.solvedProblem.service.SolvedProblemSyncService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,6 +24,7 @@ import java.util.Map;
 public class AuthController {
 
     private final AuthService authService;
+    private final SolvedProblemSyncService solvedProblemSyncService;
 
     /**
      * 로그인 API
@@ -47,6 +49,7 @@ public class AuthController {
                 .createdAt(member.getCreatedAt())
                 .solvedAcId(member.getSolvedAcId())
                 .build();
+        solvedProblemSyncService.syncSolvedProblems(signUpDto.getSolvedAcId());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(memberDto);
     }

--- a/backend/src/main/java/force/ssafy/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/force/ssafy/domain/auth/controller/AuthController.java
@@ -49,7 +49,7 @@ public class AuthController {
                 .createdAt(member.getCreatedAt())
                 .solvedAcId(member.getSolvedAcId())
                 .build();
-        solvedProblemSyncService.syncSolvedProblems(signUpDto.getSolvedAcId());
+        solvedProblemSyncService.syncSolvedProblemsAsync(signUpDto.getSolvedAcId());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(memberDto);
     }

--- a/backend/src/main/java/force/ssafy/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/force/ssafy/domain/auth/service/AuthService.java
@@ -9,6 +9,7 @@ import force.ssafy.domain.member.entity.Member;
 import force.ssafy.domain.member.exception.DuplicateSolvedAcIdException;
 import force.ssafy.domain.member.exception.MemberNotFoundException;
 import force.ssafy.domain.member.repository.MemberRepository;
+import force.ssafy.domain.solvedProblem.service.SolvedProblemSyncService;
 import force.ssafy.domain.solvedac.entity.VerificationCode;
 import force.ssafy.domain.solvedac.repository.VerificationCodeRepository;
 import force.ssafy.domain.solvedac.service.SolvedAcService;
@@ -32,7 +33,6 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final SolvedAcService solvedAcService;
     private final VerificationCodeRepository verificationCodeRepository;
-
     /**
      * 회원가입 처리
      */
@@ -72,7 +72,6 @@ public class AuthService {
 
         // 회원가입 완료 후 인증 코드 삭제
         solvedAcService.deleteVerificationCode(signUpDto.getSolvedAcId());
-
         return savedMember;
     }
 

--- a/backend/src/main/java/force/ssafy/domain/member/entity/Member.java
+++ b/backend/src/main/java/force/ssafy/domain/member/entity/Member.java
@@ -29,9 +29,6 @@ public class Member implements UserDetails {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @Column(nullable = false, length = 30, unique = true)
-//    private String nickname;
-
     @Column(nullable = false, length = 100)
     private String password;
 
@@ -65,10 +62,10 @@ public class Member implements UserDetails {
         this.profileImageUrl = imageUrl;
     }
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TeamMember> teamMembers = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SolvedProblem> SolvedProblems = new ArrayList<>();
 
     @Builder

--- a/backend/src/main/java/force/ssafy/domain/solvedProblem/controller/SolvedProblemController.java
+++ b/backend/src/main/java/force/ssafy/domain/solvedProblem/controller/SolvedProblemController.java
@@ -9,6 +9,8 @@ import force.ssafy.global.util.DateUtils;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -52,5 +54,16 @@ public class SolvedProblemController {
     public ResponseEntity<SyncResultResponse> syncSolvedProblems(@PathVariable("solvedAcId") String solvedAcId) {
         SyncResultResponse syncResultResponse = solvedProblemSyncService.syncSolvedProblems(solvedAcId);
         return ResponseEntity.ok(syncResultResponse);
+    }
+
+    @PostMapping("/sync-async/{solvedAcId}")
+    public Mono<ResponseEntity<SyncResultResponse>> syncSolvedProblemsAsync(@PathVariable("solvedAcId") String solvedAcId) {
+        log.info("비동기 동기화 요청 - solvedAcId: {}", solvedAcId);
+        return solvedProblemSyncService.syncSolvedProblemsAsync(solvedAcId)
+            .map(ResponseEntity::ok)
+            .doOnSuccess(response ->
+                log.info("비동기 동기화 요청 완료 - solvedAcId: {}", solvedAcId))
+            .doOnError(error ->
+                log.error("비동기 동기화 요청 실패 - solvedAcId: {}, error: {}", solvedAcId, error.getMessage()));
     }
 }

--- a/backend/src/main/java/force/ssafy/domain/solvedProblem/service/SolvedProblemSyncService.java
+++ b/backend/src/main/java/force/ssafy/domain/solvedProblem/service/SolvedProblemSyncService.java
@@ -108,7 +108,7 @@ public class SolvedProblemSyncService {
 					.doOnNext(problems ->
 						log.info("Lambda 응답 수신 - solvedAcId : {}, 문제 수 : {}", solvedAcId, problems.size()))
 					.flatMap(problems -> processSolvedProblemsAsync(member, problems))
-					.flatMap(savedCount -> updateSyncTimeAsync(member, savedCount))
+					.flatMap(savedCount -> updateSyncTimeWithFreshMember(member.getId(), savedCount))
 					.doOnSuccess(result ->
 						log.info("비동기 동기화 성공 - 저장된 문제 수 : {}, 사용자: {}",
 							result.resultCount(), solvedAcId));
@@ -183,6 +183,15 @@ public class SolvedProblemSyncService {
 	private Mono<SyncResultResponse> updateSyncTimeAsync(Member member, int savedCount) {
 		return Mono.fromCallable(() -> {
 			member.updateLastProblemSyncTime(LocalDateTime.now());
+			return new SyncResultResponse(savedCount);
+		}).subscribeOn(Schedulers.boundedElastic());
+	}
+	private Mono<SyncResultResponse> updateSyncTimeWithFreshMember(Long memberId, int savedCount) {
+		return Mono.fromCallable(()->{
+			Member freshMember = memberRepository.findById(memberId)
+				.orElseThrow(()->new EntityNotFoundException("회원을 찾을 수 없습니다."));
+			freshMember.updateLastProblemSyncTime(LocalDateTime.now());
+			memberRepository.save(freshMember);
 			return new SyncResultResponse(savedCount);
 		}).subscribeOn(Schedulers.boundedElastic());
 	}

--- a/backend/src/main/java/force/ssafy/domain/solvedProblem/service/SolvedProblemSyncService.java
+++ b/backend/src/main/java/force/ssafy/domain/solvedProblem/service/SolvedProblemSyncService.java
@@ -2,6 +2,7 @@ package force.ssafy.domain.solvedProblem.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import force.ssafy.domain.member.entity.Member;
 import force.ssafy.domain.member.repository.MemberRepository;
 import force.ssafy.domain.problem.entity.Problem;
@@ -16,9 +17,13 @@ import force.ssafy.global.error.exception.EntityNotFoundException;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.concurrent.TimeoutException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -31,251 +36,341 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 @Slf4j
 @RequiredArgsConstructor
 public class SolvedProblemSyncService {
-    private final SolvedProblemRepository solvedProblemRepository;
-    private final MemberRepository memberRepository;
-    private final ProblemRepository problemRepository;
-    private final ObjectMapper objectMapper;
+	private final SolvedProblemRepository solvedProblemRepository;
+	private final MemberRepository memberRepository;
+	private final ProblemRepository problemRepository;
+	private final ObjectMapper objectMapper;
 
+	@Value("${aws.lambda.baekjoon-crawler-url}")
+	private String lambdaUrl;
 
-    @Value("${aws.lambda.baekjoon-crawler-url}")
-    private String lambdaUrl;
+	@Transactional(propagation = Propagation.REQUIRED)
+	public SyncResultResponse syncSolvedProblems(String solvedAcId) {
 
-    @Transactional(propagation = Propagation.REQUIRED)
-    public SyncResultResponse syncSolvedProblems(String solvedAcId) {
+		// 1. 회원 정보 조회
+		Member member = memberRepository.findBySolvedAcId(solvedAcId)
+			.orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
 
-        // 1. 회원 정보 조회
-        Member member = memberRepository.findBySolvedAcId(solvedAcId)
-                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
+		// 2. 마지막 동기화 시간 확인 (없으면 10년 전으로 설정)
+		LocalDateTime lastSyncTime = member.getLastProblemSyncTime();
+		if (lastSyncTime == null) {
+			lastSyncTime = LocalDateTime.now().minusYears(10);
+		}
 
-        // 2. 마지막 동기화 시간 확인 (없으면 10년 전으로 설정)
-        LocalDateTime lastSyncTime = member.getLastProblemSyncTime();
-        if (lastSyncTime == null) {
-            lastSyncTime = LocalDateTime.now().minusYears(10);
-        }
+		// 3. AWS Lambda 호출을 위한 요청 생성
+		CrawlRequestDto request = CrawlRequestDto.of(member, lastSyncTime);
 
-        // 3. AWS Lambda 호출을 위한 요청 생성
-        CrawlRequestDto request = CrawlRequestDto.of(member, lastSyncTime);
+		// LocalDateTime을 ISO 문자열로 변환하여 전송
+		Map<String, Object> requestMap = new HashMap<>();
+		requestMap.put("solvedAcId", request.solvedAcId());
+		requestMap.put("lastSyncTime", lastSyncTime.toString()); // ISO 8601 형식으로 변환
 
-        // LocalDateTime을 ISO 문자열로 변환하여 전송
-        Map<String, Object> requestMap = new HashMap<>();
-        requestMap.put("solvedAcId", request.solvedAcId());
-        requestMap.put("lastSyncTime", lastSyncTime.toString()); // ISO 8601 형식으로 변환
+		// 4. Lambda 호출하여 새로운 해결 문제 데이터 가져오기
+		List<SolvedProblemDto> newSolvedProblems;
+		try {
+			newSolvedProblems = callLambdaFunction(requestMap);
+		} catch (Exception e) {
+			log.error("Lambda 함수 호출 실패 - 동기화 중단: {}", e.getMessage());
+			throw e; // 예외를 다시 던져서 트랜잭션 롤백
+		}
 
-        // 4. Lambda 호출하여 새로운 해결 문제 데이터 가져오기
-        List<SolvedProblemDto> newSolvedProblems;
-        try {
-            newSolvedProblems = callLambdaFunction(requestMap);
-        } catch (Exception e) {
-            log.error("Lambda 함수 호출 실패 - 동기화 중단: {}", e.getMessage());
-            throw e; // 예외를 다시 던져서 트랜잭션 롤백
-        }
+		// 5. 가져온 데이터 처리
+		int savedCount;
+		try {
+			savedCount = processSolvedProblems(member, newSolvedProblems);
+		} catch (Exception e) {
+			log.error("문제 데이터 처리 실패 - 동기화 중단: {}", e.getMessage());
+			throw e; // 예외를 다시 던져서 트랜잭션 롤백
+		}
 
-        // 5. 가져온 데이터 처리
-        int savedCount;
-        try {
-            savedCount = processSolvedProblems(member, newSolvedProblems);
-        } catch (Exception e) {
-            log.error("문제 데이터 처리 실패 - 동기화 중단: {}", e.getMessage());
-            throw e; // 예외를 다시 던져서 트랜잭션 롤백
-        }
+		// 6. 모든 작업이 성공했을 때만 마지막 동기화 시간 업데이트
+		try {
+			member.updateLastProblemSyncTime(LocalDateTime.now());
+			log.info("동기화 성공 - 저장된 문제 수: {}, 사용자: {}", savedCount, solvedAcId);
+		} catch (Exception e) {
+			log.error("동기화 시간 업데이트 실패: {}", e.getMessage());
+			throw e; // 예외를 다시 던져서 트랜잭션 롤백
+		}
 
-        // 6. 모든 작업이 성공했을 때만 마지막 동기화 시간 업데이트
-        try {
-            member.updateLastProblemSyncTime(LocalDateTime.now());
-            log.info("동기화 성공 - 저장된 문제 수: {}, 사용자: {}", savedCount, solvedAcId);
-        } catch (Exception e) {
-            log.error("동기화 시간 업데이트 실패: {}", e.getMessage());
-            throw e; // 예외를 다시 던져서 트랜잭션 롤백
-        }
+		// 7. 결과 반환
+		return new SyncResultResponse(savedCount);
+	}
 
-        // 7. 결과 반환
-        return new SyncResultResponse(savedCount);
-    }
+	@Transactional(propagation = Propagation.REQUIRED)
+	public Mono<SyncResultResponse> syncSolvedProblemsAsync(String solvedAcId) {
+		return findMemberAsync(solvedAcId)
+			.flatMap(member -> {
+				LocalDateTime lastSyncTime = member.getLastProblemSyncTime();
+				if (lastSyncTime == null) {
+					lastSyncTime = LocalDateTime.now().minusYears(10);
+				}
+				return callLambdaFunctionAsync(member, lastSyncTime)
+					.doOnNext(problems ->
+						log.info("Lambda 응답 수신 - solvedAcId : {}, 문제 수 : {}", solvedAcId, problems.size()))
+					.flatMap(problems -> processSolvedProblemsAsync(member, problems))
+					.flatMap(savedCount -> updateSyncTimeAsync(member, savedCount))
+					.doOnSuccess(result ->
+						log.info("비동기 동기화 성공 - 저장된 문제 수 : {}, 사용자: {}",
+							result.resultCount(), solvedAcId));
+			})
+			.timeout(Duration.ofMinutes(4))
+			.doOnError(error ->
+				log.error("비동기 동기화 실패 - solvedAcId : {}, error: {}", solvedAcId, error.getMessage()))
+			.onErrorMap(TimeoutException.class, e ->
+				new RuntimeException("동기화 작업이 시간 초과되었습니다: " + solvedAcId, e))
+			.onErrorMap(Exception.class, e -> {
+				if (e instanceof RuntimeException) {
+					return e;
+				}
+				return new RuntimeException("비동기 동기화 중 오류가 발생했습니다: " + e.getMessage(), e);
+			});
+	}
 
-    private List<SolvedProblemDto> callLambdaFunction(Map<String, Object> request) {
-        try {
-            WebClient webClient = WebClient.builder()
-                    .baseUrl(lambdaUrl)
-                    .codecs(configurer ->
-                            configurer.defaultCodecs().maxInMemorySize(100 * 1024 * 1024)
-                    )
-                    .build();
+	private Mono<Member> findMemberAsync(String solvedAcId) {
+		return Mono.fromCallable(() ->
+			memberRepository.findBySolvedAcId(solvedAcId)
+				.orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."))
+		).subscribeOn(Schedulers.boundedElastic());
+	}
 
-            String response = webClient.post()
-                    .bodyValue(request)
-                    .retrieve()
-                    .bodyToMono(String.class)
-                    .timeout(Duration.ofMinutes(3))
-                    .doOnSubscribe(subscription -> log.info("요청 전송 완료, 응답 대기 중..."))
-                    .doOnNext(resp -> log.info("Lambda 응답 수신 완료 - 크기: {} bytes ({} KB)",
-                            resp.length(), resp.length() / 1024))
-                    .block();
+	private Mono<List<SolvedProblemDto>> callLambdaFunctionAsync(Member member, LocalDateTime lastSyncTime) {
+		Map<String, Object> requestMap = new HashMap<>();
+		requestMap.put("solvedAcId", member.getSolvedAcId());
+		requestMap.put("lastSyncTime", lastSyncTime.toString());
 
-            // 응답 파싱 및 오류 처리
-            return parseLambdaResponse(response);
+		return createWebClient()
+			.post()
+			.bodyValue(requestMap)
+			.retrieve()
+			.bodyToMono(String.class)
+			.timeout(Duration.ofMinutes(3))
+			.doOnSubscribe(subscription ->
+				log.debug("비동기 Lambda 요청 전송 - solvedAcId : {}", member.getSolvedAcId()))
+			.map(this::parseLambdaResponse)
+			.onErrorMap(WebClientResponseException.class, this::convertWebClientError)
+			.onErrorMap(Exception.class, e -> {
+				log.error("비동기 Lamdba 함수 호출 실패 : {}", e.getMessage(), e);
+				return new RuntimeException("비동기 Lambda 함수 호출 중 오류가 발생했습니다: " + e.getMessage(), e);
+			});
+	}
 
-        } catch (WebClientResponseException e) {
-            log.error("람다 함수 호출 실패 - HTTP 오류코드: {}, 오류 내용: {}", e.getStatusCode(), e.getMessage());
-            handleLambdaError(e);
-            // handleLambdaError에서 예외를 던지므로 여기 도달하지 않음
-            return new ArrayList<>();
-        } catch (Exception e) {
-            log.error("람다 함수 호출 실패: {}", e.getMessage(), e);
-            // 네트워크 오류나 기타 예외 시 RuntimeException으로 래핑
-            throw new RuntimeException("람다 함수 호출 중 오류가 발생했습니다: " + e.getMessage(), e);
-        }
-    }
+	private WebClient createWebClient() {
+		return WebClient.builder()
+			.baseUrl(lambdaUrl)
+			.codecs(configurer ->
+				configurer.defaultCodecs().maxInMemorySize(100 * 1024 * 1024))
+			.build();
+	}
 
-    private List<SolvedProblemDto> parseLambdaResponse(String response) {
-        try {
-            JsonNode jsonNode = objectMapper.readTree(response);
+	private RuntimeException convertWebClientError(WebClientResponseException e) {
+		log.error("비동기 Lambda 함수 호출 실패 - HTTP 오류코드 : {}, 내용 : {}", e.getStatusCode(), e.getMessage());
+		try {
+			handleLambdaError(e);
+			return new RuntimeException("Lambda 함수 호출 실패");
+		} catch (Exception handleException) {
+			return new RuntimeException("Lambda 함수 호출 실패 : " + handleException.getMessage(), handleException);
+		}
+	}
 
-            // 오류 응답인지 확인
-            if (jsonNode.has("error") && jsonNode.get("error").asBoolean()) {
-                String errorCode = jsonNode.get("errorCode").asText();
-                String message = jsonNode.get("message").asText();
+	private Mono<Integer> processSolvedProblemsAsync(Member member, List<SolvedProblemDto> newSolvedProblems) {
+		return Mono.fromCallable(() -> processSolvedProblems(member, newSolvedProblems))
+			.subscribeOn(Schedulers.boundedElastic())
+			.doOnSubscribe(subscription ->
+				log.debug("문제 데이터 처리 시작 - 대상 문제 수 : {}",
+					newSolvedProblems != null ? newSolvedProblems.size() : 0));
+	}
 
-                log.error("람다 함수에서 오류 응답: errorCode={}, message={}", errorCode, message);
-                handleErrorCode(errorCode, message);
-            }
+	private Mono<SyncResultResponse> updateSyncTimeAsync(Member member, int savedCount) {
+		return Mono.fromCallable(() -> {
+			member.updateLastProblemSyncTime(LocalDateTime.now());
+			return new SyncResultResponse(savedCount);
+		}).subscribeOn(Schedulers.boundedElastic());
+	}
 
-            // 정상 응답인 경우 - 직접 배열로 반환
-            if (jsonNode.isArray()) {
-                return objectMapper.readValue(
-                        jsonNode.toString(),
-                        objectMapper.getTypeFactory().constructCollectionType(List.class, SolvedProblemDto.class)
-                );
-            } else {
-                log.warn("예상하지 못한 응답 형태: {}", response);
-                return new ArrayList<>();
-            }
+	private List<SolvedProblemDto> callLambdaFunction(Map<String, Object> request) {
+		try {
+			WebClient webClient = WebClient.builder()
+				.baseUrl(lambdaUrl)
+				.codecs(configurer ->
+					configurer.defaultCodecs().maxInMemorySize(100 * 1024 * 1024)
+				)
+				.build();
 
-        } catch (IllegalArgumentException e) {
-            // IllegalArgumentException 먼저 처리
-            throw e;
-        } catch (RuntimeException e) {
-            // 다른 RuntimeException 처리
-            throw e;
-        } catch (Exception e) {
-            log.error("람다 응답 파싱 실패: {}", e.getMessage(), e);
-            return new ArrayList<>();
-        }
-    }
+			String response = webClient.post()
+				.bodyValue(request)
+				.retrieve()
+				.bodyToMono(String.class)
+				.timeout(Duration.ofMinutes(3))
+				.doOnSubscribe(subscription -> log.info("요청 전송 완료, 응답 대기 중..."))
+				.doOnNext(resp -> log.info("Lambda 응답 수신 완료 - 크기: {} bytes ({} KB)",
+					resp.length(), resp.length() / 1024))
+				.block();
 
-    private void handleLambdaError(WebClientResponseException e) {
-        HttpStatus statusCode = (HttpStatus) e.getStatusCode();
-        String responseBody = e.getResponseBodyAsString();
+			// 응답 파싱 및 오류 처리
+			return parseLambdaResponse(response);
 
-        try {
-            JsonNode responseNode = objectMapper.readTree(responseBody);
+		} catch (WebClientResponseException e) {
+			log.error("람다 함수 호출 실패 - HTTP 오류코드: {}, 오류 내용: {}", e.getStatusCode(), e.getMessage());
+			handleLambdaError(e);
+			// handleLambdaError에서 예외를 던지므로 여기 도달하지 않음
+			return new ArrayList<>();
+		} catch (Exception e) {
+			log.error("람다 함수 호출 실패: {}", e.getMessage(), e);
+			// 네트워크 오류나 기타 예외 시 RuntimeException으로 래핑
+			throw new RuntimeException("람다 함수 호출 중 오류가 발생했습니다: " + e.getMessage(), e);
+		}
+	}
 
-            // 오류 응답인지 확인
-            if (responseNode.has("errorCode")) {
-                String errorCode = responseNode.get("errorCode").asText();
-                String message = responseNode.get("message").asText();
-                handleErrorCode(errorCode, message);
-            }
-        } catch (IllegalArgumentException ex) {
-            throw ex;
-        } catch (Exception ex) {
-            log.error("오류 응답 파싱 실패: {}", ex.getMessage());
-        }
+	private List<SolvedProblemDto> parseLambdaResponse(String response) {
+		try {
+			JsonNode jsonNode = objectMapper.readTree(response);
 
-        // 기본 오류 처리
-        if (statusCode == HttpStatus.BAD_REQUEST) {
-            throw new IllegalArgumentException("잘못된 요청입니다: " + responseBody);
-        } else if (statusCode == HttpStatus.INTERNAL_SERVER_ERROR) {
-            throw new RuntimeException("람다 함수 내부 오류: " + responseBody);
-        } else {
-            throw new RuntimeException("람다 함수 호출 실패: " + statusCode + " - " + responseBody);
-        }
-    }
+			// 오류 응답인지 확인
+			if (jsonNode.has("error") && jsonNode.get("error").asBoolean()) {
+				String errorCode = jsonNode.get("errorCode").asText();
+				String message = jsonNode.get("message").asText();
 
-    private void handleErrorCode(String errorCode, String message) {
-        switch (errorCode) {
-            case "INVALID_DATE_FORMAT":
-                throw new IllegalArgumentException("날짜 형식 오류: " + message);
-            case "NETWORK_ERROR":
-                throw new RuntimeException("네트워크 오류: " + message);
-            case "INVALID_REQUEST":
-                throw new IllegalArgumentException("잘못된 요청: " + message);
-            case "EXTERNAL_SERVICE_ERROR":
-                throw new RuntimeException("외부 서비스 오류: " + message);
-            case "INTERNAL_ERROR":
-                throw new RuntimeException("람다 함수 내부 오류: " + message);
-            case "INVALID_JSON":
-                throw new IllegalArgumentException("JSON 파싱 오류: " + message);
-            case "USER_NOT_FOUND":
-                throw new IllegalArgumentException("사용자를 찾을 수 없습니다: " + message);
-            default:
-                throw new RuntimeException("람다 함수 오류: " + message);
-        }
-    }
+				log.error("람다 함수에서 오류 응답: errorCode={}, message={}", errorCode, message);
+				handleErrorCode(errorCode, message);
+			}
 
-    private int processSolvedProblems(Member member, List<SolvedProblemDto> newSolvedProblems) {
-        if (newSolvedProblems == null || newSolvedProblems.isEmpty()) {
-            log.info("처리할 새로운 문제가 없습니다.");
-            return 0;
-        }
+			// 정상 응답인 경우 - 직접 배열로 반환
+			if (jsonNode.isArray()) {
+				return objectMapper.readValue(
+					jsonNode.toString(),
+					objectMapper.getTypeFactory().constructCollectionType(List.class, SolvedProblemDto.class)
+				);
+			} else {
+				log.warn("예상하지 못한 응답 형태: {}", response);
+				return new ArrayList<>();
+			}
 
-        List<SolvedProblemDto> sortedProblems = newSolvedProblems.stream()
-                .sorted(Comparator.comparing(SolvedProblemDto::solvedDate))
-                .toList();
+		} catch (IllegalArgumentException e) {
+			// IllegalArgumentException 먼저 처리
+			throw e;
+		} catch (RuntimeException e) {
+			// 다른 RuntimeException 처리
+			throw e;
+		} catch (Exception e) {
+			log.error("람다 응답 파싱 실패: {}", e.getMessage(), e);
+			return new ArrayList<>();
+		}
+	}
 
-        log.info("데이터 정렬 완료: 총 {}개 문제를 시간순으로 정렬 ({} → {})",
-                sortedProblems.size(),
-                sortedProblems.isEmpty() ? "없음" : sortedProblems.get(0).solvedDate(),
-                sortedProblems.isEmpty() ? "없음" : sortedProblems.get(sortedProblems.size() - 1).solvedDate());
+	private void handleLambdaError(WebClientResponseException e) {
+		HttpStatus statusCode = (HttpStatus)e.getStatusCode();
+		String responseBody = e.getResponseBodyAsString();
 
-        int savedCount = 0;
-        int errorCount = 0;
-        int duplicateCount = 0;
+		try {
+			JsonNode responseNode = objectMapper.readTree(responseBody);
 
-        for (SolvedProblemDto dto : sortedProblems) {
-            try {
-                // 이미 존재하는 제출인지 확인
-                if (solvedProblemRepository.existsBySubmissionId(dto.submissionId())) {
-                    log.debug("이미 존재하는 submission 입니다: {}", dto.submissionId());
-                    duplicateCount++;
-                    continue;
-                }
+			// 오류 응답인지 확인
+			if (responseNode.has("errorCode")) {
+				String errorCode = responseNode.get("errorCode").asText();
+				String message = responseNode.get("message").asText();
+				handleErrorCode(errorCode, message);
+			}
+		} catch (IllegalArgumentException ex) {
+			throw ex;
+		} catch (Exception ex) {
+			log.error("오류 응답 파싱 실패: {}", ex.getMessage());
+		}
 
-                // 문제 존재 여부 확인
-                Problem problem = problemRepository.findByProblemNumber(dto.problemNumber())
-                        .orElse(null);
-                if (problem == null) {
-                    log.warn("문제를 찾을 수 없습니다. problemNumber: {}", dto.problemNumber());
-                    errorCount++;
-                    continue;
-                }
+		// 기본 오류 처리
+		if (statusCode == HttpStatus.BAD_REQUEST) {
+			throw new IllegalArgumentException("잘못된 요청입니다: " + responseBody);
+		} else if (statusCode == HttpStatus.INTERNAL_SERVER_ERROR) {
+			throw new RuntimeException("람다 함수 내부 오류: " + responseBody);
+		} else {
+			throw new RuntimeException("람다 함수 호출 실패: " + statusCode + " - " + responseBody);
+		}
+	}
 
-                boolean previousSolved = solvedProblemRepository.existsByMemberAndProblem(member, problem);
+	private void handleErrorCode(String errorCode, String message) {
+		switch (errorCode) {
+			case "INVALID_DATE_FORMAT":
+				throw new IllegalArgumentException("날짜 형식 오류: " + message);
+			case "NETWORK_ERROR":
+				throw new RuntimeException("네트워크 오류: " + message);
+			case "INVALID_REQUEST":
+				throw new IllegalArgumentException("잘못된 요청: " + message);
+			case "EXTERNAL_SERVICE_ERROR":
+				throw new RuntimeException("외부 서비스 오류: " + message);
+			case "INTERNAL_ERROR":
+				throw new RuntimeException("람다 함수 내부 오류: " + message);
+			case "INVALID_JSON":
+				throw new IllegalArgumentException("JSON 파싱 오류: " + message);
+			case "USER_NOT_FOUND":
+				throw new IllegalArgumentException("사용자를 찾을 수 없습니다: " + message);
+			default:
+				throw new RuntimeException("람다 함수 오류: " + message);
+		}
+	}
 
-                SolvedProblem solvedProblem = SolvedProblem.builder()
-                        .member(member)
-                        .problem(problem)
-                        .solvedDate(dto.solvedDate())
-                        .language(dto.language())
-                        .timeComplexity(dto.timeComplexity())
-                        .spaceComplexity(dto.spaceComplexity())
-                        .submitUrl(dto.submitUrl())
-                        .isFirstSolved(!previousSolved)
-                        .submissionId(dto.submissionId())
-                        .build();
+	private int processSolvedProblems(Member member, List<SolvedProblemDto> newSolvedProblems) {
+		if (newSolvedProblems == null || newSolvedProblems.isEmpty()) {
+			log.info("처리할 새로운 문제가 없습니다.");
+			return 0;
+		}
 
-                solvedProblemRepository.save(solvedProblem);
-                savedCount++;
+		List<SolvedProblemDto> sortedProblems = newSolvedProblems.stream()
+			.sorted(Comparator.comparing(SolvedProblemDto::solvedDate))
+			.toList();
 
-            } catch (Exception e) {
-                log.error("문제 처리 중 오류 발생 - submissionId: {}, problemNumber: {}, error: {}",
-                        dto.submissionId(), dto.problemNumber(), e.getMessage());
-                errorCount++;
-            }
-        }
+		log.info("데이터 정렬 완료: 총 {}개 문제를 시간순으로 정렬 ({} → {})",
+			sortedProblems.size(),
+			sortedProblems.isEmpty() ? "없음" : sortedProblems.get(0).solvedDate(),
+			sortedProblems.isEmpty() ? "없음" : sortedProblems.get(sortedProblems.size() - 1).solvedDate());
 
-        log.info("문제 처리 완료 - 성공: {}, 중복: {}, 오류: {}, 전체: {}",
-                savedCount, duplicateCount, errorCount, newSolvedProblems.size());
+		int savedCount = 0;
+		int errorCount = 0;
+		int duplicateCount = 0;
 
-        return savedCount;
-    }
+		for (SolvedProblemDto dto : sortedProblems) {
+			try {
+				// 이미 존재하는 제출인지 확인
+				if (solvedProblemRepository.existsBySubmissionId(dto.submissionId())) {
+					log.debug("이미 존재하는 submission 입니다: {}", dto.submissionId());
+					duplicateCount++;
+					continue;
+				}
+
+				// 문제 존재 여부 확인
+				Problem problem = problemRepository.findByProblemNumber(dto.problemNumber())
+					.orElse(null);
+				if (problem == null) {
+					log.warn("문제를 찾을 수 없습니다. problemNumber: {}", dto.problemNumber());
+					errorCount++;
+					continue;
+				}
+
+				boolean previousSolved = solvedProblemRepository.existsByMemberAndProblem(member, problem);
+
+				SolvedProblem solvedProblem = SolvedProblem.builder()
+					.member(member)
+					.problem(problem)
+					.solvedDate(dto.solvedDate())
+					.language(dto.language())
+					.timeComplexity(dto.timeComplexity())
+					.spaceComplexity(dto.spaceComplexity())
+					.submitUrl(dto.submitUrl())
+					.isFirstSolved(!previousSolved)
+					.submissionId(dto.submissionId())
+					.build();
+
+				solvedProblemRepository.save(solvedProblem);
+				savedCount++;
+
+			} catch (Exception e) {
+				log.error("문제 처리 중 오류 발생 - submissionId: {}, problemNumber: {}, error: {}",
+					dto.submissionId(), dto.problemNumber(), e.getMessage());
+				errorCount++;
+			}
+		}
+
+		log.info("문제 처리 완료 - 성공: {}, 중복: {}, 오류: {}, 전체: {}",
+			savedCount, duplicateCount, errorCount, newSolvedProblems.size());
+
+		return savedCount;
+	}
 }

--- a/backend/src/test/java/force/ssafy/domain/solvedProblem/service/MockPerformanceTest.java
+++ b/backend/src/test/java/force/ssafy/domain/solvedProblem/service/MockPerformanceTest.java
@@ -1,0 +1,370 @@
+package force.ssafy.domain.solvedProblem.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import force.ssafy.domain.member.entity.Member;
+import force.ssafy.domain.member.repository.MemberRepository;
+import force.ssafy.domain.problem.entity.Problem;
+import force.ssafy.domain.problem.repository.ProblemRepository;
+import force.ssafy.domain.solvedProblem.controller.dto.response.SyncResultResponse;
+import force.ssafy.domain.solvedProblem.repository.SolvedProblemRepository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.*;
+import java.util.stream.IntStream;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MockPerformanceTest {
+
+	@Mock
+	private SolvedProblemRepository solvedProblemRepository;
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private ProblemRepository problemRepository;
+
+	@Mock
+	private ObjectMapper objectMapper;
+
+	@InjectMocks
+	private SolvedProblemSyncService syncService;
+
+	private Member mockMember;
+	private Problem mockProblem;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		// Mock 회원 생성
+		mockMember = Member.builder()
+			.solvedAcId("testUser")
+			.name("테스트유저")
+			.password("password")
+			.encryptionKey("key")
+			.lastProblemSyncTime(null)
+			.build();
+
+		// Mock 문제 생성
+		mockProblem = Problem.builder()
+			.problemNumber(1000L)
+			.title("테스트 문제")
+			.build();
+
+		// 성능 테스트에서는 실제 서비스 호출을 하지 않으므로 Mock 설정 최소화
+		when(memberRepository.findBySolvedAcId(anyString())).thenReturn(Optional.of(mockMember));
+	}
+
+	// mockLambdaResponse 메서드 제거 - 실제로 사용되지 않음
+
+	@Test
+	void 동기_vs_비동기_성능_비교_시뮬레이션() {
+		System.out.println("=== 동기 vs 비동기 성능 비교 (시뮬레이션) ===");
+
+		String solvedAcId = "testUser";
+
+		// 동기 방식 시뮬레이션 (1초 대기)
+		long syncStart = System.currentTimeMillis();
+		simulateWork(1000); // 1초 Lambda 호출 시뮬레이션
+		simulateWork(100);  // DB 처리 시뮬레이션
+		long syncDuration = System.currentTimeMillis() - syncStart;
+
+		// 비동기 방식 시뮬레이션 (동일한 작업을 비동기로)
+		long asyncStart = System.currentTimeMillis();
+		CompletableFuture<Void> asyncTask = CompletableFuture.runAsync(() -> {
+			simulateWork(1000); // Lambda 호출
+			simulateWork(100);  // DB 처리
+		});
+		try {
+			asyncTask.get(); // 완료 대기
+		} catch (Exception e) {
+			System.err.println("비동기 작업 실패: " + e.getMessage());
+		}
+		long asyncDuration = System.currentTimeMillis() - asyncStart;
+
+		// 결과 출력
+		System.out.println("동기 방식 소요시간: " + syncDuration + "ms");
+		System.out.println("비동기 방식 소요시간: " + asyncDuration + "ms");
+		System.out.println("차이: " + (syncDuration - asyncDuration) + "ms");
+
+		// 단일 요청에서는 큰 차이가 없을 것으로 예상
+		System.out.println("\n💡 단일 요청에서는 성능 차이가 미미합니다.");
+		System.out.println("   실제 성능 차이는 동시 요청에서 확인할 수 있습니다.");
+	}
+
+	@Test
+	void 동시_요청_성능_비교() throws InterruptedException {
+		int requestCount = 5;
+		System.out.println("=== 동시 " + requestCount + "개 요청 성능 비교 ===");
+
+		// 동기 방식 (순차 처리)
+		testSynchronousRequests(requestCount);
+
+		System.out.println(); // 구분선
+
+		// 비동기 방식 (병렬 처리)
+		testAsynchronousRequests(requestCount);
+	}
+
+	private void testSynchronousRequests(int requestCount) {
+		System.out.println("\n--- 동기 방식 (순차 처리) ---");
+		long overallStart = System.currentTimeMillis();
+		List<Long> durations = new ArrayList<>();
+
+		for (int i = 0; i < requestCount; i++) {
+			long start = System.currentTimeMillis();
+
+			// 동기 작업 시뮬레이션 (Lambda 1초 + DB 처리 0.1초)
+			simulateWork(1000); // Lambda 호출
+			simulateWork(100);  // DB 처리
+
+			long duration = System.currentTimeMillis() - start;
+			durations.add(duration);
+			System.out.println("  요청 " + (i + 1) + ": " + duration + "ms");
+		}
+
+		long overallDuration = System.currentTimeMillis() - overallStart;
+		double avgDuration = durations.stream().mapToLong(Long::longValue).average().orElse(0);
+
+		System.out.println("동기 방식 전체 소요시간: " + overallDuration + "ms");
+		System.out.println("동기 방식 평균 응답시간: " + String.format("%.1f", avgDuration) + "ms");
+	}
+
+	private void testAsynchronousRequests(int requestCount) {
+		System.out.println("\n--- 비동기 방식 (병렬 처리) ---");
+		long overallStart = System.currentTimeMillis();
+
+		// 모든 요청을 비동기로 동시 실행
+		List<CompletableFuture<Long>> futures = new ArrayList<>();
+
+		for (int i = 0; i < requestCount; i++) {
+			final int index = i;
+			CompletableFuture<Long> future = CompletableFuture.supplyAsync(() -> {
+				long start = System.currentTimeMillis();
+
+				// 비동기 작업 시뮬레이션
+				simulateWork(1000); // Lambda 호출
+				simulateWork(100);  // DB 처리
+
+				long duration = System.currentTimeMillis() - start;
+				System.out.println("  요청 " + (index + 1) + ": " + duration + "ms");
+				return duration;
+			});
+			futures.add(future);
+		}
+
+		// 모든 비동기 작업 완료 대기
+		List<Long> durations = new ArrayList<>();
+		for (CompletableFuture<Long> future : futures) {
+			try {
+				durations.add(future.get());
+			} catch (Exception e) {
+				System.err.println("비동기 작업 실패: " + e.getMessage());
+			}
+		}
+
+		long overallDuration = System.currentTimeMillis() - overallStart;
+		double avgDuration = durations.stream().mapToLong(Long::longValue).average().orElse(0);
+
+		System.out.println("비동기 방식 전체 소요시간: " + overallDuration + "ms");
+		System.out.println("비동기 방식 평균 응답시간: " + String.format("%.1f", avgDuration) + "ms");
+	}
+
+	@Test
+	void 스레드_풀_크기별_성능_비교() throws InterruptedException {
+		int[] poolSizes = {1, 2, 5, 10};
+		int taskCount = 8;
+
+		System.out.println("=== 스레드 풀 크기별 성능 비교 ===");
+		System.out.println("작업 수: " + taskCount + "개, 각 작업당 1초 소요");
+
+		for (int poolSize : poolSizes) {
+			testWithThreadPool(poolSize, taskCount);
+		}
+
+		System.out.println("\n💡 분석:");
+		System.out.println("   - 스레드 풀 크기 1: 순차 실행과 동일 (8초 소요)");
+		System.out.println("   - 스레드 풀 크기가 작업 수보다 크면 모든 작업이 동시 실행 (1초 소요)");
+		System.out.println("   - 적절한 스레드 풀 크기 = CPU 코어 수 × 2 정도 권장");
+	}
+
+	private void testWithThreadPool(int poolSize, int taskCount) throws InterruptedException {
+		System.out.println("\n--- 스레드 풀 크기: " + poolSize + " ---");
+
+		long start = System.currentTimeMillis();
+		ExecutorService executor = Executors.newFixedThreadPool(poolSize);
+
+		List<Future<Void>> futures = new ArrayList<>();
+		for (int i = 0; i < taskCount; i++) {
+			final int taskIndex = i;
+			futures.add(executor.submit(() -> {
+				System.out.println("    작업 " + (taskIndex + 1) + " 시작");
+				simulateWork(1000); // 1초 작업
+				System.out.println("    작업 " + (taskIndex + 1) + " 완료");
+				return null;
+			}));
+		}
+
+		// 모든 작업 완료 대기
+		for (Future<Void> future : futures) {
+			try {
+				future.get();
+			} catch (Exception e) {
+				System.err.println("작업 실패: " + e.getMessage());
+			}
+		}
+
+		long duration = System.currentTimeMillis() - start;
+		System.out.println("  스레드 풀 크기 " + poolSize + " 결과: " + duration + "ms");
+
+		executor.shutdown();
+		executor.awaitTermination(10, TimeUnit.SECONDS);
+	}
+
+	@Test
+	void 메모리_사용량_비교_시뮬레이션() {
+		System.out.println("=== 메모리 사용량 비교 시뮬레이션 ===");
+
+		Runtime runtime = Runtime.getRuntime();
+
+		// 초기 메모리 상태
+		runtime.gc();
+		long initialMemory = runtime.totalMemory() - runtime.freeMemory();
+		System.out.println("초기 메모리 사용량: " + (initialMemory / 1024 / 1024) + "MB");
+
+		// 동기 방식 메모리 사용량 시뮬레이션
+		long beforeSync = runtime.totalMemory() - runtime.freeMemory();
+		List<Object> syncObjects = new ArrayList<>();
+		for (int i = 0; i < 1000; i++) {
+			syncObjects.add("동기작업데이터" + i); // 메모리 사용 시뮬레이션
+		}
+		simulateWork(100); // 작업 시뮬레이션
+		long afterSync = runtime.totalMemory() - runtime.freeMemory();
+
+		System.out.println("동기 방식 메모리 증가량: " +
+			((afterSync - beforeSync) / 1024) + "KB");
+
+		// 메모리 정리
+		syncObjects.clear();
+		runtime.gc();
+
+		// 비동기 방식 메모리 사용량 시뮬레이션
+		long beforeAsync = runtime.totalMemory() - runtime.freeMemory();
+		List<CompletableFuture<Void>> asyncTasks = new ArrayList<>();
+
+		for (int i = 0; i < 5; i++) {
+			final int index = i;
+			CompletableFuture<Void> task = CompletableFuture.runAsync(() -> {
+				List<Object> taskObjects = new ArrayList<>();
+				for (int j = 0; j < 200; j++) {
+					taskObjects.add("비동기작업데이터" + index + "_" + j);
+				}
+				simulateWork(50);
+			});
+			asyncTasks.add(task);
+		}
+
+		// 모든 비동기 작업 완료 대기
+		CompletableFuture.allOf(asyncTasks.toArray(new CompletableFuture[0])).join();
+
+		long afterAsync = runtime.totalMemory() - runtime.freeMemory();
+		System.out.println("비동기 방식 메모리 증가량: " +
+			((afterAsync - beforeAsync) / 1024) + "KB");
+
+		runtime.gc();
+		long finalMemory = runtime.totalMemory() - runtime.freeMemory();
+		System.out.println("최종 메모리 사용량: " + (finalMemory / 1024 / 1024) + "MB");
+
+		System.out.println("\n💡 일반적으로 비동기 방식이 메모리를 더 효율적으로 사용합니다.");
+	}
+
+	@Test
+	void 처리량_비교_테스트() {
+		System.out.println("=== 처리량(Throughput) 비교 테스트 ===");
+
+		int totalRequests = 20;
+		int timeWindowSeconds = 10; // 10초 동안
+
+		System.out.println(timeWindowSeconds + "초 동안 " + totalRequests + "개 요청 처리");
+
+		// 동기 방식 처리량
+		long syncStart = System.currentTimeMillis();
+		int syncCompleted = 0;
+		long syncEndTime = syncStart + (timeWindowSeconds * 1000);
+
+		for (int i = 0; i < totalRequests; i++) {
+			if (System.currentTimeMillis() > syncEndTime) break;
+
+			simulateWork(400); // 0.4초 작업
+			syncCompleted++;
+
+			if (System.currentTimeMillis() > syncEndTime) break;
+		}
+		long syncActualDuration = System.currentTimeMillis() - syncStart;
+
+		System.out.println("\n--- 동기 방식 ---");
+		System.out.println("처리 완료: " + syncCompleted + "/" + totalRequests + " 요청");
+		System.out.println("실제 소요 시간: " + syncActualDuration + "ms");
+		System.out.println("초당 처리량: " + String.format("%.1f",
+			(double) syncCompleted / (syncActualDuration / 1000.0)) + " 요청/초");
+
+		// 비동기 방식 처리량
+		long asyncStart = System.currentTimeMillis();
+		List<CompletableFuture<Void>> asyncTasks = new ArrayList<>();
+
+		for (int i = 0; i < totalRequests; i++) {
+			CompletableFuture<Void> task = CompletableFuture.runAsync(() -> {
+				simulateWork(400); // 0.4초 작업
+			});
+			asyncTasks.add(task);
+		}
+
+		// 모든 작업 완료 대기 (최대 10초)
+		try {
+			CompletableFuture.allOf(asyncTasks.toArray(new CompletableFuture[0]))
+				.get(timeWindowSeconds, TimeUnit.SECONDS);
+		} catch (TimeoutException e) {
+			System.out.println("비동기 작업 시간 초과");
+		} catch (Exception e) {
+			System.err.println("비동기 작업 실패: " + e.getMessage());
+		}
+
+		long asyncDuration = System.currentTimeMillis() - asyncStart;
+
+		System.out.println("\n--- 비동기 방식 ---");
+		System.out.println("처리 완료: " + totalRequests + "/" + totalRequests + " 요청");
+		System.out.println("실제 소요 시간: " + asyncDuration + "ms");
+		System.out.println("초당 처리량: " + String.format("%.1f",
+			(double) totalRequests / (asyncDuration / 1000.0)) + " 요청/초");
+
+		System.out.println("\n💡 비동기 방식의 처리량이 " +
+			String.format("%.1f", (double) totalRequests * asyncDuration / (syncActualDuration * totalRequests)) +
+			"배 더 높습니다.");
+	}
+
+	// 작업 시뮬레이션 메서드
+	private void simulateWork(long millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+}

--- a/frontend/src/api/solvedProblemApi.js
+++ b/frontend/src/api/solvedProblemApi.js
@@ -21,7 +21,7 @@ export const solvedProblemApi = {
   syncSolvedProblems(solvedAcId) {
     try {
       return api.post(
-        `/solved-problems/sync/${solvedAcId}`,
+        `/solved-problems/sync-async/${solvedAcId}`,
         {},
         {
           timeout: 120000, // 2분 (120초) 타임아웃


### PR DESCRIPTION
## 🔍 변경사항
<!-- 이번 PR에서 변경된 내용을 간략히 설명해주세요 -->
- 해결한 문제 동기화 시 `webflux`의` .block()` 을 사용하여 동기적으로 기능을 구현한 것을 비동기`Mono`를 이용하여 구현하기
## 💬리뷰 요구사항
<!-- 코드 리뷰시 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. -->
- member 객체의 last problem sync time을 업데이트하는데 있어서 스레드 변경에 의해 변경감지가 잘 일어나지 않는 상황을 위해 memberId로 객체를 새롭게 조회하는 방식 사용
    - 멤버 조회 -> 멤버 필드 수정 (객체를 전달하지 않고 id를 전달하여 repository로 새롭게 조회)
## 🔗 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 (ex. #123) -->
#118 
## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
<img width="2554" height="362" alt="image" src="https://github.com/user-attachments/assets/23a98d87-cbb0-4a17-9e1b-3eccc13b5fad" />

